### PR TITLE
upmerge main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
       - name: Check Packages
         run: |
           if [ "$GITHUB_EVENT_NAME" != "pull_request" ] ; then

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -32,6 +32,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+
       - name: Check Packages
         run: |
           if [ "$GITHUB_EVENT_NAME" != "pull_request" ] ; then

--- a/act.yaml
+++ b/act.yaml
@@ -129,6 +129,31 @@ releases:
     x86_64-windows:
       url: https://github.com/nektos/act/releases/download/v0.2.33/act_Windows_x86_64.zip
       sha256: d9639b77cb2fc81a935a8f5e0c3086ace72638af1a3552618c5084779a462706
+  0.2.34:
+    aarch64-linux:
+      url: https://github.com/nektos/act/releases/download/v0.2.34/act_Linux_arm64.tar.gz
+      sha256: 48602704c0d098edffd7cc6f3bf05bf33836275c25f0e6d70ad00408e7b23dfa
+    aarch64-macos:
+      url: https://github.com/nektos/act/releases/download/v0.2.34/act_Darwin_arm64.tar.gz
+      sha256: d522cac12993bcf0e6e9ef905c05a70d791e5cc5a5760aa52abbcdf198a9aeb5
+    aarch64-windows:
+      url: https://github.com/nektos/act/releases/download/v0.2.34/act_Windows_arm64.zip
+      sha256: 5845033d66841f3844c77a3242b5be72866eec1ba9161630b8d1360999e38c74
+    x86-linux:
+      url: https://github.com/nektos/act/releases/download/v0.2.34/act_Linux_i386.tar.gz
+      sha256: eeaa3219a22f08f8a2d1f684aed5ad8abf5b00f264926fbd0ef9c69de507ecf9
+    x86-windows:
+      url: https://github.com/nektos/act/releases/download/v0.2.34/act_Windows_i386.zip
+      sha256: 66a97aab1c28799f7974e6c0ea6186d549923ff2c1663bbd355785c912efeb43
+    x86_64-linux:
+      url: https://github.com/nektos/act/releases/download/v0.2.34/act_Linux_x86_64.tar.gz
+      sha256: b8429964db6f265ddc1834802acd3ffb891249165edd6a9228e94c3d0cbbd8c9
+    x86_64-macos:
+      url: https://github.com/nektos/act/releases/download/v0.2.34/act_Darwin_x86_64.tar.gz
+      sha256: 8f315cc9668d70d0a1a530dc0c1720eb2ce360e51ba2032d7271e7b2c5f2376c
+    x86_64-windows:
+      url: https://github.com/nektos/act/releases/download/v0.2.34/act_Windows_x86_64.zip
+      sha256: 6a0b44d13fd3639c6f9ae9603c65cf5b62a5ad228e7f79f63d4151a56e8d1789
 installs:
   0.2.28:
     any-any:
@@ -137,4 +162,4 @@ installs:
         README.md: ${doc_dir}
         act${exe_ext}: bin/
       tests:
-        - act${exe_ext} --version
+      - act${exe_ext} --version

--- a/changie.yaml
+++ b/changie.yaml
@@ -1,6 +1,5 @@
 name: changie
-description: Automated changelog tool for preparing releases with lots of customization
-  options
+description: Automated changelog tool for preparing releases with lots of customization options
 homepage: https://github.com/miniscruff/changie
 repository: https://github.com/miniscruff/changie
 releases:
@@ -29,6 +28,31 @@ releases:
     x86_64-windows:
       url: https://github.com/miniscruff/changie/releases/download/v1.10.0/changie_1.10.0_windows_amd64.zip
       sha256: a55d1d8e13df37982a84e91a5717d6dff3e7536377b8952fc7a2a26e48d59e29
+  1.10.1:
+    aarch64-linux:
+      url: https://github.com/miniscruff/changie/releases/download/v1.10.1/changie_1.10.1_linux_arm64.tar.gz
+      sha256: e9760c6871e2f025e16840b99250275e7effcd9c81bc0876eca4c2288108e483
+    aarch64-macos:
+      url: https://github.com/miniscruff/changie/releases/download/v1.10.1/changie_1.10.1_darwin_arm64.tar.gz
+      sha256: 26a65b871034cecadeae8e0a6ca1c721364595631dc5dc9b530786a1826fb33a
+    aarch64-windows:
+      url: https://github.com/miniscruff/changie/releases/download/v1.10.1/changie_1.10.1_windows_arm64.zip
+      sha256: dd6326a8852644e66b8ca1704def3a0a546a5956d796e69493aa7037dd348d6c
+    x86-linux:
+      url: https://github.com/miniscruff/changie/releases/download/v1.10.1/changie_1.10.1_linux_386.tar.gz
+      sha256: 58a1a94063915c0bbf3fcfa94c96aeeab0aafc86e68d202d02960d906fd3898f
+    x86-windows:
+      url: https://github.com/miniscruff/changie/releases/download/v1.10.1/changie_1.10.1_windows_386.zip
+      sha256: ab571f6d83fca572750d462ef71b61253bc828938aabed84a0f15c2b40af251a
+    x86_64-linux:
+      url: https://github.com/miniscruff/changie/releases/download/v1.10.1/changie_1.10.1_linux_amd64.tar.gz
+      sha256: 58f1b65322fc2f7e3153332fe521c3bc7d89da403b8367fe7666cb09cc0e66e9
+    x86_64-macos:
+      url: https://github.com/miniscruff/changie/releases/download/v1.10.1/changie_1.10.1_darwin_amd64.tar.gz
+      sha256: f5ae33fcc64bfe4a78e7353125ac9bf2408ae691c91e23a03df9864548e057ed
+    x86_64-windows:
+      url: https://github.com/miniscruff/changie/releases/download/v1.10.1/changie_1.10.1_windows_amd64.zip
+      sha256: fd8bb56b68556d12bb8a064263d8fdf204cfa5dcbeb02bf68c561c03996762bf
   1.8.0:
     aarch64-linux:
       url: https://github.com/miniscruff/changie/releases/download/v1.8.0/changie_1.8.0_linux_arm64.tar.gz
@@ -113,4 +137,4 @@ installs:
         README.md: ${doc_dir}
         changie${exe_ext}: bin/
       tests:
-        - changie${exe_ext} --version
+      - changie${exe_ext} --version

--- a/ci/check-packages
+++ b/ci/check-packages
@@ -125,7 +125,7 @@ def has_ci_changed(paths: List[Path]) -> bool:
 
 
 def list_all_packages() -> List[Path]:
-    return list(ROOT_DIR.glob("*.yaml"))
+    return list(ROOT_DIR.glob("*.yaml")) + list(ROOT_DIR.glob("*/index.yaml"))
 
 
 def list_packages_to_check(target: str) -> List[Path]:
@@ -188,7 +188,7 @@ def download_clyde(url: str) -> None:
 
 def check_packages(packages: List[Path]) -> int:
     # We must run the test in the current directory for now
-    package_names = [x.name for x in packages]
+    package_names = [x.relative_to(ROOT_DIR) for x in packages]
     cmd = [which("clydetools"), "check"] + package_names
     proc = subprocess.run(cmd, cwd=ROOT_DIR)
     return proc.returncode
@@ -201,6 +201,7 @@ def main() -> int:
 
     parser.add_argument("target", choices=["main", "next"])
     parser.add_argument("-a", "--all", action="store_true")
+    parser.add_argument("-d", "--dry-run", action="store_true")
 
     args = parser.parse_args()
 
@@ -218,7 +219,10 @@ def main() -> int:
         eprint("None")
         return 0
     for package in packages:
-        eprint(f"- {package.name}")
+        eprint(f"- {package.relative_to(ROOT_DIR)}")
+
+    if args.dry_run:
+        return 0
 
     if args.target == "main":
         clyde_url = find_clyde_release_url()

--- a/clyde.yaml
+++ b/clyde.yaml
@@ -63,6 +63,16 @@ releases:
     x86_64-windows:
       url: https://github.com/agateau/clyde/releases/download/0.4.0/clyde-0.4.0-x86_64-windows.zip
       sha256: 607096f975d37b820656e7a23de6ff23b28c5ead31748545670dec2f149a71f5
+  0.4.1:
+    x86_64-linux:
+      url: https://github.com/agateau/clyde/releases/download/0.4.1/clyde-0.4.1-x86_64-linux.tar.gz
+      sha256: 9cb6a4c067280699eb215b91ed689240b1a23f1799f812fdd6e7c56a0feda2a3
+    x86_64-macos:
+      url: https://github.com/agateau/clyde/releases/download/0.4.1/clyde-0.4.1-x86_64-macos.tar.gz
+      sha256: c3b7f519ca7f24abf0fcea0f8b97c8bd1f25010db2b1200e0e5ce9f046b77db9
+    x86_64-windows:
+      url: https://github.com/agateau/clyde/releases/download/0.4.1/clyde-0.4.1-x86_64-windows.zip
+      sha256: a8f70571d245d6ac6dda3861506cc7fddaf1d04265a739a27956ebdad02adb30
 installs:
   0.1.0:
     any-any:

--- a/cmake.yaml
+++ b/cmake.yaml
@@ -551,6 +551,25 @@ releases:
     x86_64-windows:
       url: https://github.com/Kitware/CMake/releases/download/v3.25.0-rc4/cmake-3.25.0-rc4-windows-x86_64.zip
       sha256: f9aea71b1f4728778c53142eb9a4565f2c442cef4eaf00d385f0a1c36d23609a
+  3.25.1:
+    aarch64-linux:
+      url: https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-aarch64.tar.gz
+      sha256: b1c9b85e0ee4db0eb335e8d8868b4527224db402d404119a4b1a5e081a89445f
+    aarch64-windows:
+      url: https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-windows-arm64.zip
+      sha256: 422f4d55be5744f6814070132bfc9bc67e92834bd4e8ab23bf57caaaaf295b47
+    any-macos:
+      url: https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-macos-universal.tar.gz
+      sha256: e95e75ea506189785355a7e8dd86b059780a5613b9e62ab6e7419d6bfba3510b
+    x86-windows:
+      url: https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-windows-i386.zip
+      sha256: 6f661cd493bc868aa10c8ae3ac1e88caabec45ce8b3f035d5fd165ab9a08bc0c
+    x86_64-linux:
+      url: https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-linux-x86_64.tar.gz
+      sha256: 3a5008b613eeb0724edeb3c15bf91d6ce518eb8eebc6ee758f89a0f4ff5d1fd6
+    x86_64-windows:
+      url: https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-windows-x86_64.zip
+      sha256: d93958d87cc9b91983489f0b37a268b03a3c891894d11f5437fa2a5ce94aab24
 installs:
   3.20.0:
     any-any:
@@ -563,7 +582,6 @@ installs:
         bin/ctest: bin/
         man: share/man
         share: share
-      extra_files: {}
       tests:
       - ccmake --version
       - cmake --version
@@ -579,7 +597,6 @@ installs:
         bin/ctest: bin/
         man: share/man
         share: share
-      extra_files: {}
       tests:
       - ccmake --version
       - cmake --version
@@ -594,7 +611,6 @@ installs:
         bin/ctest.exe: bin/
         man: share/man
         share: share
-      extra_files: {}
       tests:
       - cmake.exe --version
       - cmake-gui.exe --version

--- a/croc.yaml
+++ b/croc.yaml
@@ -47,6 +47,31 @@ releases:
     x86_64-windows:
       url: https://github.com/schollz/croc/releases/download/v9.6.1/croc_9.6.1_Windows-64bit.zip
       sha256: db5e546ccf1140e5621a2024092159a2170946908fab79e9d9c8f76e17d55706
+  9.6.2:
+    aarch64-linux:
+      url: https://github.com/schollz/croc/releases/download/v9.6.2/croc_9.6.2_Linux-ARM64.tar.gz
+      sha256: fd288d68ee2e8cf6f09c5d0f99a647b58c8907959731a8118b770366bdbe6944
+    aarch64-macos:
+      url: https://github.com/schollz/croc/releases/download/v9.6.2/croc_9.6.2_macOS-ARM64.tar.gz
+      sha256: a5891690b4eeaf2084782f1116634fbfccb42e58ca68d22174d2aad7023e6605
+    aarch64-windows:
+      url: https://github.com/schollz/croc/releases/download/v9.6.2/croc_9.6.2_Windows-ARM64.zip
+      sha256: 9db19070f24fa0bbd6dca56f2ce72ad9941ecea15215bae967d35ec13b8b0fe8
+    x86-linux:
+      url: https://github.com/schollz/croc/releases/download/v9.6.2/croc_9.6.2_Linux-32bit.tar.gz
+      sha256: 07c56196879c9cc4ea06a0f8a4fe7a92fadf2e84050761379ea5daf89302da79
+    x86-windows:
+      url: https://github.com/schollz/croc/releases/download/v9.6.2/croc_9.6.2_Windows-32bit.zip
+      sha256: 7cd7ab8681063b9cda00a44e5fc57bba9757911fc595c447286f90c6caa4176a
+    x86_64-linux:
+      url: https://github.com/schollz/croc/releases/download/v9.6.2/croc_9.6.2_Linux-64bit.tar.gz
+      sha256: 9a4cb807244a3e9ef1bb0067b8761e24607d0b1c807bc7eafbab1a9d426c9dcd
+    x86_64-macos:
+      url: https://github.com/schollz/croc/releases/download/v9.6.2/croc_9.6.2_macOS-64bit.tar.gz
+      sha256: f63569a386791c84110efb189076b2c880e994faf2ec8bb870d2fb64265b5638
+    x86_64-windows:
+      url: https://github.com/schollz/croc/releases/download/v9.6.2/croc_9.6.2_Windows-64bit.zip
+      sha256: c46c2d6d2b92cca3347fab2d63544819baae9611460c67baf78ffe399c7555ab
 installs:
   9.6.0:
     any-any:
@@ -55,4 +80,4 @@ installs:
         README.md: ${doc_dir}
         croc${exe_ext}: bin/
       tests:
-        - croc${exe_ext} --version
+      - croc${exe_ext} --version

--- a/datree.yaml
+++ b/datree.yaml
@@ -1243,6 +1243,28 @@ releases:
     x86_64-windows:
       url: https://github.com/datreeio/datree/releases/download/1.8.1/datree-cli_1.8.1_windows_x86_64.zip
       sha256: 25c2d5a17cd1bc7781da7e5976ccb541e217ecd2f8029fcf7438a9368562f32e
+  1.8.8:
+    aarch64-linux:
+      url: https://github.com/datreeio/datree/releases/download/1.8.8/datree-cli_1.8.8_Linux_arm64.zip
+      sha256: 02519d32c87f6920caccabd459360373e15450afce18e16a6fbc7e884eae9a0e
+    aarch64-macos:
+      url: https://github.com/datreeio/datree/releases/download/1.8.8/datree-cli_1.8.8_Darwin_arm64.zip
+      sha256: 19c928d1de66aa629c170c263cf63079cd74fc4d2232aebe3aea0f1a254433da
+    x86-linux:
+      url: https://github.com/datreeio/datree/releases/download/1.8.8/datree-cli_1.8.8_Linux_386.zip
+      sha256: b67555aa45c7f330cae033aefb9e10712fd565159bfc2f73c575ec8ec23e9eac
+    x86-windows:
+      url: https://github.com/datreeio/datree/releases/download/1.8.8/datree-cli_1.8.8_windows_386.zip
+      sha256: 78681fa1dd3dab56685f9eef8af4d3aabec938fa9a326edf913d6737b8c85cbc
+    x86_64-linux:
+      url: https://github.com/datreeio/datree/releases/download/1.8.8/datree-cli_1.8.8_Linux_x86_64.zip
+      sha256: 93718a745e00ca09124094440a8d5c67bc18929d08e9a9f14cd7d772d609d4f2
+    x86_64-macos:
+      url: https://github.com/datreeio/datree/releases/download/1.8.8/datree-cli_1.8.8_Darwin_x86_64.zip
+      sha256: 1724a3cc7e409c058373243ea0cabe59f00414d769e7d0fb692387c09d8a3598
+    x86_64-windows:
+      url: https://github.com/datreeio/datree/releases/download/1.8.8/datree-cli_1.8.8_windows_x86_64.zip
+      sha256: 39b9d985dd0b8af66c58b6a012aa4485c953fb1a634ffa46c33e76ebd0be8cbb
 installs:
   0.2.1:
     any-any:
@@ -1251,5 +1273,5 @@ installs:
         README.md: ${doc_dir}
         changelog.txt: ${doc_dir}
         datree${exe_ext}: bin/
-      extra_files: {}
-      tests: []
+      tests:
+      - datree${exe_ext} version

--- a/devdash.yaml
+++ b/devdash.yaml
@@ -30,3 +30,5 @@ installs:
         LICENCE: ${doc_dir}
         README.md: ${doc_dir}
         devdash${exe_ext}: bin/
+      tests:
+        - devdash${exe_ext} version

--- a/difftastic.yaml
+++ b/difftastic.yaml
@@ -92,5 +92,5 @@ installs:
     any-any:
       files:
         difft${exe_ext}: bin/
-      extra_files: {}
-      tests: []
+      tests:
+        - difft${exe_ext} --version

--- a/envoy.yaml
+++ b/envoy.yaml
@@ -139,4 +139,5 @@ installs:
       strip: 2
       files:
         envoy: bin/
-
+      tests:
+        - envoy --version

--- a/fd.yaml
+++ b/fd.yaml
@@ -54,6 +54,25 @@ releases:
     x86_64-windows:
       url: https://github.com/sharkdp/fd/releases/download/v8.5.3/fd-v8.5.3-x86_64-pc-windows-msvc.zip
       sha256: 461c182d897ea5821ea69a9e15d383497be3a9d4188f60a57e32be892544bfe3
+  8.6.0:
+    aarch64-linux:
+      url: https://github.com/sharkdp/fd/releases/download/v8.6.0/fd-v8.6.0-aarch64-unknown-linux-gnu.tar.gz
+      sha256: be0096fcd18536158a37b2d582beea193cf882efbe8f3085dfb3431cc4334dcb
+    x86-linux:
+      url: https://github.com/sharkdp/fd/releases/download/v8.6.0/fd-v8.6.0-i686-unknown-linux-musl.tar.gz
+      sha256: 08947d672b08346cde1133cc53edb5069c4778debb1b0b0c8dbee4ec2036303c
+    x86-windows:
+      url: https://github.com/sharkdp/fd/releases/download/v8.6.0/fd-v8.6.0-i686-pc-windows-msvc.zip
+      sha256: 2783168c0af2c78ee293b447a073b06898711dd70e81405296b884c59943c6d1
+    x86_64-linux:
+      url: https://github.com/sharkdp/fd/releases/download/v8.6.0/fd-v8.6.0-x86_64-unknown-linux-musl.tar.gz
+      sha256: 9fdb370648fb8256fc9a36355c652546bd4c62925babcad80f95f90f74fc81e7
+    x86_64-macos:
+      url: https://github.com/sharkdp/fd/releases/download/v8.6.0/fd-v8.6.0-x86_64-apple-darwin.tar.gz
+      sha256: f8629345125c130fac82e2ce2bd3aba8cd68f923076081409c9d8791b731693e
+    x86_64-windows:
+      url: https://github.com/sharkdp/fd/releases/download/v8.6.0/fd-v8.6.0-x86_64-pc-windows-msvc.zip
+      sha256: 9cff97eb1c024ed94cc76a4b2d924ab3df04b37e7430c282b8188a13f1653ebe
 installs:
   8.4.0:
     any-any:
@@ -62,5 +81,5 @@ installs:
         README.md: ${doc_dir}
         fd${exe_ext}: bin/
         fd.1: share/man/man1/
-      extra_files: {}
-      tests: []
+      tests:
+      - fd${exe_ext} --version

--- a/fzf.yaml
+++ b/fzf.yaml
@@ -212,5 +212,5 @@ installs:
     any-any:
       files:
         fzf${exe_ext}: bin/
-      extra_files: {}
-      tests: []
+      tests:
+        - fzf${exe_ext} --version

--- a/gh.yaml
+++ b/gh.yaml
@@ -346,7 +346,11 @@ installs:
         LICENSE: ${doc_dir}
         bin/gh${exe_ext}: bin/
         share: share
+      tests:
+        - gh${exe_ext} --version
     any-windows:
       files:
         LICENSE: ${doc_dir}
         bin/gh${exe_ext}: bin/
+      tests:
+        - gh${exe_ext} --version

--- a/git-bonsai.yaml
+++ b/git-bonsai.yaml
@@ -40,3 +40,5 @@ installs:
       files:
         README.md: ${doc_dir}
         git-bonsai${exe_ext}: bin/
+      tests:
+        - git-bonsai${exe_ext} --version

--- a/git-filter-repo.yaml
+++ b/git-filter-repo.yaml
@@ -26,6 +26,8 @@ installs:
         Documentation/man1: share/man/man1
         README.md: ${doc_dir}
         git-filter-repo: bin/
+      tests:
+        - git-filter-repo --version
     any-macos:
       strip: 1
       files:
@@ -33,3 +35,5 @@ installs:
         Documentation/man1: share/man/man1
         README.md: ${doc_dir}
         git-filter-repo: bin/
+      tests:
+        - git-filter-repo --version

--- a/gitea.yaml
+++ b/gitea.yaml
@@ -96,3 +96,5 @@ installs:
     any-any:
       files:
         ${asset_name}: bin/gitea${exe_ext}
+      tests:
+        - gitea${exe_ext} --version

--- a/glab.yaml
+++ b/glab.yaml
@@ -1,37 +1,113 @@
----
 name: glab
 description: A GitLab CLI tool bringing GitLab to your command line
-homepage: "https://glab.readthedocs.io/"
-repository: "https://github.com/profclems/glab"
+homepage: https://glab.readthedocs.io/
+repository: https://gitlab.com/gitlab-org/cli
 releases:
   1.21.0:
     x86_64-linux:
-      url: "https://github.com/profclems/glab/releases/download/v1.21.0/glab_1.21.0_Linux_x86_64.tar.gz"
+      url: https://github.com/profclems/glab/releases/download/v1.21.0/glab_1.21.0_Linux_x86_64.tar.gz
       sha256: fc7a6af233797285348280e71c533574125aa52d72b73b65596d9934d70fcedd
   1.22.0:
     aarch64-linux:
-      url: "https://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_Linux_arm64.tar.gz"
+      url: https://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_Linux_arm64.tar.gz
       sha256: 72b83d99c9fb99ed5ba04cc50f5acf90e1d4bedbc7c0d950eae7eb8375d0068b
     x86-linux:
-      url: "https://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_Linux_i386.tar.gz"
+      url: https://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_Linux_i386.tar.gz
       sha256: 96c8983254eb0e6b517fce925b105e83c871759e28f4b46ff8335b6081d86fa9
     x86-windows:
-      url: "https://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_Windows_i386.zip"
+      url: https://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_Windows_i386.zip
       sha256: 43e86b78e919ec0a1947157c1eeaf62fa8bc03087f09affb28293af939ac4389
     x86_64-linux:
-      url: "https://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_Linux_x86_64.tar.gz"
+      url: https://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_Linux_x86_64.tar.gz
       sha256: 7d70af94648cd7720899315ddd9efdf981769f636b3cf6976508a939d5248a5f
     x86_64-macos:
-      url: "https://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_macOS_x86_64.tar.gz"
+      url: https://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_macOS_x86_64.tar.gz
       sha256: 050c6d54fb973fda1405a26aa9ccde9fe5a3e5cc3bb975ed430063e56504786f
     x86_64-windows:
-      url: "https://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_Windows_x86_64.zip"
+      url: https://github.com/profclems/glab/releases/download/v1.22.0/glab_1.22.0_Windows_x86_64.zip
       sha256: 1b07931cbd9547fdf33bc5c636a5e70bc01d7ef68768cff13f9655623ce411d8
+  1.23.0:
+    aarch64-linux:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.0/downloads/glab_1.23.0_Linux_arm64.tar.gz
+      sha256: 8de32ce4bf05b5204f3cb09b9a909c0cbab9194f7cdf96809db525960000b94a
+    aarch64-macos:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.0/downloads/glab_1.23.0_macOS_arm64.tar.gz
+      sha256: df054959d582ff8ebd22fc4c959c41c06111a6e48fbe349ffec65442c9a11cb5
+    x86-linux:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.0/downloads/glab_1.23.0_Linux_i386.tar.gz
+      sha256: e7d1e502c93c0fb912d3d4937a7dc13e891b976561a67d5b120e3ced680f84b0
+    x86-windows:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.0/downloads/glab_1.23.0_Windows_i386.zip
+      sha256: 87cced7408ed7bb7419e789c81432a312ec66b27c59b154bca46b9d747af7090
+    x86_64-linux:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.0/downloads/glab_1.23.0_Linux_x86_64.tar.gz
+      sha256: 19b34c8ef2e4dacb59e6b6682c300242bf3a5c028d0183e70144008d6af0f606
+    x86_64-macos:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.0/downloads/glab_1.23.0_macOS_x86_64.tar.gz
+      sha256: d579ee97decccbf35e3ed62b7ff50f189e7550ab6e6f056ad669b4dee2c0a2a1
+    x86_64-windows:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.0/downloads/glab_1.23.0_Windows_x86_64.zip
+      sha256: 6d7413f31e6f787bcb0ec4fcdba6143d8fdf1a17669225ff38cacbd00f1a6dde
+  1.23.1:
+    aarch64-linux:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.1/downloads/glab_1.23.1_Linux_arm64.tar.gz
+      sha256: 3287a0368b3c5ab30eab2c5b1ba0b7f46fc61ec9624ec980dda24a632a38f5b1
+    aarch64-macos:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.1/downloads/glab_1.23.1_macOS_arm64.tar.gz
+      sha256: ffc23d7b898c41d286ba427aa402588547e0a32444828e0dcf947be2911640f8
+    x86-linux:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.1/downloads/glab_1.23.1_Linux_i386.tar.gz
+      sha256: c346fb14e4f3bfb5c28a5d93b64507245a10cc21ef261233a58e86f4ce4adfa5
+    x86-windows:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.1/downloads/glab_1.23.1_Windows_i386.zip
+      sha256: 246b0a9e1879107d433fdae6d9b0e4924be2da0d48a0cd6ec7634eaca992bf74
+    x86_64-linux:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.1/downloads/glab_1.23.1_Linux_x86_64.tar.gz
+      sha256: 89e48f028b72e73a3037ddf57be8f08561b8b147ceb14edf7e4ab4e9baa2e24f
+    x86_64-macos:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.1/downloads/glab_1.23.1_macOS_x86_64.tar.gz
+      sha256: 218425da34bacb2782a9b543c23c8da19d9e6763d6193df1172c78b45d4a487a
+    x86_64-windows:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.23.1/downloads/glab_1.23.1_Windows_x86_64.zip
+      sha256: af195fdef0ebde08f3bbb2ab21a8763ebb1bbee90b6579165a3bb1fbf27620e5
+  1.24.1:
+    aarch64-linux:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.24.1/downloads/glab_1.24.1_Linux_arm64.tar.gz
+      sha256: be8236671f5fb6c1acb2c89678df5b3719f58e27537569ad2adcd1d6ef274e29
+    aarch64-macos:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.24.1/downloads/glab_1.24.1_macOS_arm64.tar.gz
+      sha256: 7384d3fdcab89813fd537d129b7376b799760956eb0bff264714ad367bb3b9c9
+    x86-linux:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.24.1/downloads/glab_1.24.1_Linux_i386.tar.gz
+      sha256: db84c013bfbe73408b2598bf1fbefb7ecaa32a5d9483a6fdd3ea3bab326025e2
+    x86-windows:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.24.1/downloads/glab_1.24.1_Windows_i386.zip
+      sha256: 85e9b4ee96337ebe48b040a552b2cb7327be86d235ff6e2c9d555be32c9fe56c
+    x86_64-linux:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.24.1/downloads/glab_1.24.1_Linux_x86_64.tar.gz
+      sha256: 4b34f0736210bd8b9cab315dd0c2408ee8a794f712f6d7e1d8042e04a6473116
+    x86_64-macos:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.24.1/downloads/glab_1.24.1_macOS_x86_64.tar.gz
+      sha256: 04f3927264379a74885c05575725a229daaa7e47d96a66b4268ba7b38a8d8ca4
+    x86_64-windows:
+      url: https://gitlab.com/gitlab-org/cli/-/releases/v1.24.1/downloads/glab_1.24.1_Windows_x86_64.zip
+      sha256: 6b553a556ba7011a0c9fcf8a5f947ab60c6aabfaada47391ea7ba5703b08392b
 installs:
   1.21.0:
     any-any:
       files:
-        CHANGELOG.md: "${doc_dir}"
-        LICENSE: "${doc_dir}"
-        README.md: "${doc_dir}"
-        "bin/glab${exe_ext}": bin/
+        CHANGELOG.md: ${doc_dir}
+        LICENSE: ${doc_dir}
+        README.md: ${doc_dir}
+        bin/glab${exe_ext}: bin/
+      tests:
+      - glab${exe_ext} --version
+  1.23.0:
+    any-any:
+      files:
+        LICENSE: ${doc_dir}
+        README.md: ${doc_dir}
+        bin/glab${exe_ext}: bin/
+      tests:
+      - glab${exe_ext} --version
+fetcher: Auto

--- a/gron.yaml
+++ b/gron.yaml
@@ -33,3 +33,5 @@ installs:
     any-any:
       files:
         gron${exe_ext}: bin/
+      tests:
+        - gron${exe_ext} --version

--- a/gum.yaml
+++ b/gum.yaml
@@ -165,3 +165,5 @@ installs:
         README.md: ${doc_dir}
         gum${exe_ext}: bin/
         manpages/gum.1.gz: share/man/man1/
+      tests:
+        - gum${exe_ext} --version

--- a/hexyl.yaml
+++ b/hexyl.yaml
@@ -22,6 +22,44 @@ releases:
     x86_64-windows:
       url: https://github.com/sharkdp/hexyl/releases/download/v0.10.0/hexyl-v0.10.0-x86_64-pc-windows-msvc.zip
       sha256: cff955c53eb622f500ce1cde29e15ab62456315c2ad2edf4eb06fd1604ae3113
+  0.11.0:
+    aarch64-linux:
+      url: https://github.com/sharkdp/hexyl/releases/download/v0.11.0/hexyl-v0.11.0-aarch64-unknown-linux-gnu.tar.gz
+      sha256: f5f31e0533158602d6a9f3921972ac551da399a9e3cd8fd1fe43c1f9c6e69456
+    x86-linux:
+      url: https://github.com/sharkdp/hexyl/releases/download/v0.11.0/hexyl-v0.11.0-i686-unknown-linux-musl.tar.gz
+      sha256: 4bc92b8f52627380c6f365b96771348366ce755b0e6af2773c7b89138d324006
+    x86-windows:
+      url: https://github.com/sharkdp/hexyl/releases/download/v0.11.0/hexyl-v0.11.0-i686-pc-windows-msvc.zip
+      sha256: 82500c36aaaac50d2afeaa84d4b95de100dc3a54376eda15db4b451b3290a8b9
+    x86_64-linux:
+      url: https://github.com/sharkdp/hexyl/releases/download/v0.11.0/hexyl-v0.11.0-x86_64-unknown-linux-musl.tar.gz
+      sha256: fa7ba09ab2a1ae894488209e8acb6a1c9e7ae2af80dbcf9abc9c2da3dfd2b4fd
+    x86_64-macos:
+      url: https://github.com/sharkdp/hexyl/releases/download/v0.11.0/hexyl-v0.11.0-x86_64-apple-darwin.tar.gz
+      sha256: 8df3a837e70a49800db625ccda4b39eb76f3827cffcbb6f1d8d3fce74732752d
+    x86_64-windows:
+      url: https://github.com/sharkdp/hexyl/releases/download/v0.11.0/hexyl-v0.11.0-x86_64-pc-windows-msvc.zip
+      sha256: 761651b91ec330ac3aa6366dfcafa5b3f8d52bab8a5f7875a07530859c1e9c72
+  0.12.0:
+    aarch64-linux:
+      url: https://github.com/sharkdp/hexyl/releases/download/v0.12.0/hexyl-v0.12.0-aarch64-unknown-linux-gnu.tar.gz
+      sha256: 79230bcd6ace25c3d8e005cb30c56a99f453ad66fb72136a5efc99543887608b
+    x86-linux:
+      url: https://github.com/sharkdp/hexyl/releases/download/v0.12.0/hexyl-v0.12.0-i686-unknown-linux-musl.tar.gz
+      sha256: 9061537cbeeb402995cbfc9d7714b35029c0e9ab922afc988090cee15b78ce75
+    x86-windows:
+      url: https://github.com/sharkdp/hexyl/releases/download/v0.12.0/hexyl-v0.12.0-i686-pc-windows-msvc.zip
+      sha256: 9de5e964519f4eba797063b75bc970a350e9ec98fa7b44f6ffd13f81a73e588e
+    x86_64-linux:
+      url: https://github.com/sharkdp/hexyl/releases/download/v0.12.0/hexyl-v0.12.0-x86_64-unknown-linux-musl.tar.gz
+      sha256: 4270e3deefd645fcb8c61a84fdcec7c93e88f873e2a025d67493262e50a9082f
+    x86_64-macos:
+      url: https://github.com/sharkdp/hexyl/releases/download/v0.12.0/hexyl-v0.12.0-x86_64-apple-darwin.tar.gz
+      sha256: a63da6109cdf08bc9fadd45d2f35434700b56a43bd393b1f507d69c777d692f4
+    x86_64-windows:
+      url: https://github.com/sharkdp/hexyl/releases/download/v0.12.0/hexyl-v0.12.0-x86_64-pc-windows-msvc.zip
+      sha256: adbfd61777a88342cc7d58d0df9a7482db34f97f8702079d3719aca9f4ec490c
   0.4.0:
     aarch64-linux:
       url: https://github.com/sharkdp/hexyl/foo
@@ -37,3 +75,5 @@ installs:
         README.md: ${doc_dir}
         hexyl${exe_ext}: bin/
         hexyl.1: share/man/man1/
+      tests:
+      - hexyl${exe_ext} --version

--- a/hyperfine.yaml
+++ b/hyperfine.yaml
@@ -101,3 +101,5 @@ installs:
         README.md: ${doc_dir}
         hyperfine${exe_ext}: bin/
         hyperfine.1: share/man/man1/
+      tests:
+        - hyperfine${exe_ext} --version

--- a/icoutils/extra_files/icotool
+++ b/icoutils/extra_files/icotool
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec "$CLYDE_INST_DIR/opt/icoutils/bin/icotool.exe" "$@"

--- a/icoutils/extra_files/icotool.bat
+++ b/icoutils/extra_files/icotool.bat
@@ -1,0 +1,2 @@
+@echo off
+%CLYDE_INST_DIR%\opt\icoutils\bin\icotool.exe %1 %2 %3 %4 %5 %6 %7 %8 %9

--- a/icoutils/extra_files/wrestool
+++ b/icoutils/extra_files/wrestool
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+exec "$CLYDE_INST_DIR/opt/icoutils/bin/wrestool.exe" "$@"

--- a/icoutils/extra_files/wrestool.bat
+++ b/icoutils/extra_files/wrestool.bat
@@ -1,0 +1,2 @@
+@echo off
+%CLYDE_INST_DIR%\opt\icoutils\bin\wrestool.exe %1 %2 %3 %4 %5 %6 %7 %8 %9

--- a/icoutils/index.yaml
+++ b/icoutils/index.yaml
@@ -1,0 +1,21 @@
+name: icoutils
+homepage: https://sourceforge.net/projects/unix-utils/
+description: tools to manipulate .ico files
+releases:
+  0.32.3:
+    x86_64-windows:
+      url: "https://downloads.sourceforge.net/project/unix-utils/icoutils/icoutils-0.32.3-x86_64.zip"
+      sha256: 1773b553fed5565004606d8732d9980ecec82cdccf35103700d71a17b4059723
+installs:
+  0.32.3:
+    x86_64-windows:
+      strip: 1
+      files:
+        share/man: share/man
+        bin: opt/icoutils/bin
+        share/locale: opt/icoutils/share/locale
+      extra_files:
+        icotool.bat: bin/
+        icotool: bin/
+        wrestool.bat: bin/
+        wrestool: bin/

--- a/just.yaml
+++ b/just.yaml
@@ -124,5 +124,5 @@ installs:
         README.md: ${doc_dir}
         just${exe_ext}: bin/
         just.1: share/man/man1/
-      extra_files: {}
-      tests: []
+      tests:
+        - just${exe_ext} --version

--- a/lazydocker.yaml
+++ b/lazydocker.yaml
@@ -35,3 +35,5 @@ installs:
         LICENSE: ${doc_dir}
         README.md: ${doc_dir}
         lazydocker${exe_ext}: bin/
+      tests:
+        - lazydocker${exe_ext} --version

--- a/lurk.yaml
+++ b/lurk.yaml
@@ -12,3 +12,5 @@ installs:
     any-linux:
       files:
         lurk: bin/
+      tests:
+        - lurk --version

--- a/lychee.yaml
+++ b/lychee.yaml
@@ -28,8 +28,10 @@ installs:
     any-any:
       files:
         lychee${exe_ext}: bin/
-      extra_files: {}
+      tests:
+        - lychee${exe_ext} --help
     any-windows:
       files:
         ${asset_name}: bin/lychee${exe_ext}
-      extra_files: {}
+      tests:
+        - lychee${exe_ext} --help

--- a/miniserve.yaml
+++ b/miniserve.yaml
@@ -28,3 +28,5 @@ installs:
     any-any:
       files:
         ${asset_name}: bin/miniserve${exe_ext}
+      tests:
+        - miniserve${exe_ext} --version

--- a/ninja.yaml
+++ b/ninja.yaml
@@ -1,0 +1,21 @@
+name: ninja
+description: a small build system with a focus on speed
+homepage: https://ninja-build.org
+repository: https://github.com/ninja-build/ninja
+releases:
+  1.11.1:
+    x86_64-linux:
+      url: https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-linux.zip
+      sha256: b901ba96e486dce377f9a070ed4ef3f79deb45f4ffe2938f8e7ddc69cfb3df77
+    x86_64-windows:
+      url: https://github.com/ninja-build/ninja/releases/download/v1.11.1/ninja-win.zip
+      sha256: 524b344a1a9a55005eaf868d991e090ab8ce07fa109f1820d40e74642e289abc
+installs:
+  1.11.1:
+    any-any:
+      files:
+        ninja${exe_ext}: bin/
+      tests:
+      - ninja${exe_ext} --version
+fetcher: !GitHub
+  arch: x86_64

--- a/node16.yaml
+++ b/node16.yaml
@@ -35,4 +35,8 @@ installs:
         README.md: ${doc_dir}
         LICENSE: ${doc_dir}
         CHANGELOG.md: ${doc_dir}
-
+      tests:
+        - corepack${exe_ext} --version
+        - node${exe_ext} --version
+        - npm${exe_ext} --version
+        - npx${exe_ext} --version

--- a/nushell.yaml
+++ b/nushell.yaml
@@ -167,6 +167,22 @@ releases:
     x86_64-windows:
       url: https://github.com/nushell/nushell/releases/download/0.72.0/nu-0.72.0-x86_64-pc-windows-msvc.zip
       sha256: bb51a43b10b0e5afc9d62b27d8d12d340d9c2add7df2467d46076cfd3d7d85c2
+  0.72.1:
+    aarch64-linux:
+      url: https://github.com/nushell/nushell/releases/download/0.72.1/nu-0.72.1-aarch64-unknown-linux-gnu.tar.gz
+      sha256: a683926e7fc6acf0d88a2a2f7dc4707d4d299fcaa001131a058c696a63af8d72
+    aarch64-macos:
+      url: https://github.com/nushell/nushell/releases/download/0.72.1/nu-0.72.1-aarch64-apple-darwin.tar.gz
+      sha256: 99d4d7344f5d632c8691d111ecee22faa851b7444074770515091ee543bc77ec
+    x86_64-linux:
+      url: https://github.com/nushell/nushell/releases/download/0.72.1/nu-0.72.1-x86_64-unknown-linux-musl.tar.gz
+      sha256: 4bf42995b23c2b2e6aacbf06f49a6f66830c568a969c1e5e8d875e33164b5ff7
+    x86_64-macos:
+      url: https://github.com/nushell/nushell/releases/download/0.72.1/nu-0.72.1-x86_64-apple-darwin.tar.gz
+      sha256: f4a601b46b0ba7cbaf120c2dd3f95536b365563bfddc244edadc794a30b238dd
+    x86_64-windows:
+      url: https://github.com/nushell/nushell/releases/download/0.72.1/nu-0.72.1-x86_64-pc-windows-msvc.zip
+      sha256: 665190278a4cd5c8bfe3cd9ba8f010cbd032847612a2d2b03017a985e531474a
 installs:
   0.64.0:
     any-any:
@@ -178,8 +194,6 @@ installs:
         nu_plugin_gstat${exe_ext}: bin/
         nu_plugin_inc${exe_ext}: bin/
         nu_plugin_query${exe_ext}: bin/
-      extra_files: {}
-      tests: []
     any-windows:
       files:
         LICENSE: ${doc_dir}
@@ -191,8 +205,6 @@ installs:
         nu_plugin_gstat${exe_ext}: bin/
         nu_plugin_inc${exe_ext}: bin/
         nu_plugin_query${exe_ext}: bin/
-      extra_files: {}
-      tests: []
   0.71.0:
     any-any:
       strip: 1
@@ -205,8 +217,8 @@ installs:
         nu_plugin_gstat${exe_ext}: bin/
         nu_plugin_inc${exe_ext}: bin/
         nu_plugin_query${exe_ext}: bin/
-      extra_files: {}
-      tests: []
+      tests:
+      - nu${exe_ext} --version
     any-windows:
       files:
         LICENSE: ${doc_dir}
@@ -219,5 +231,6 @@ installs:
         nu_plugin_gstat${exe_ext}: bin/
         nu_plugin_inc${exe_ext}: bin/
         nu_plugin_query${exe_ext}: bin/
-      extra_files: {}
-      tests: []
+      tests:
+      - nu${exe_ext} --version
+fetcher: Auto

--- a/pandoc.yaml
+++ b/pandoc.yaml
@@ -50,6 +50,8 @@ installs:
       files:
         bin: bin
         share: share
+      tests:
+        - pandoc${exe_ext} --version
     any-windows:
       strip: 1
       files:
@@ -57,3 +59,5 @@ installs:
         COPYRIGHT.txt: ${doc_dir}
         MANUAL.html: ${doc_dir}
         pandoc${exe_ext}: bin/
+      tests:
+        - pandoc${exe_ext} --version

--- a/rclone.yaml
+++ b/rclone.yaml
@@ -108,5 +108,5 @@ installs:
         git-log.txt: ${doc_dir}
         rclone${exe_ext}: bin/
         rclone.1: share/man/man1/
-      extra_files: {}
-      tests: []
+      tests:
+        - rclone${exe_ext} --version

--- a/ripgrep.yaml
+++ b/ripgrep.yaml
@@ -22,6 +22,8 @@ installs:
         doc/GUIDE.md: ${doc_dir}
         doc/rg.1: share/man/man1/
         rg${exe_ext}: bin/
+      tests:
+        - rg${exe_ext} --version
     x86_64-windows:
       strip: 1
       files:
@@ -31,3 +33,5 @@ installs:
         doc/FAQ.md: ${doc_dir}
         doc/GUIDE.md: ${doc_dir}
         rg${exe_ext}: bin/
+      tests:
+        - rg${exe_ext} --version

--- a/sd.yaml
+++ b/sd.yaml
@@ -15,3 +15,5 @@ installs:
     any-any:
       files:
         ${asset_name}: bin/sd
+      tests:
+        - sd${exe_ext} --version

--- a/skim.yaml
+++ b/skim.yaml
@@ -15,4 +15,5 @@ installs:
     any-any:
       files:
         sk: bin/
-      extra_files: {}
+      tests:
+        - sk${exe_ext} --version

--- a/sqlite.yaml
+++ b/sqlite.yaml
@@ -14,3 +14,5 @@ installs:
     any-any:
       files:
         sqlite3: bin/
+      tests:
+        - sqlite3${exe_ext} --version

--- a/starship.yaml
+++ b/starship.yaml
@@ -1,6 +1,5 @@
 name: starship
-description: The minimal, blazing-fast, and infinitely customizable prompt for any
-  shell!
+description: The minimal, blazing-fast, and infinitely customizable prompt for any shell!
 homepage: https://starship.rs
 repository: https://github.com/starship/starship
 releases:
@@ -79,6 +78,31 @@ releases:
     x86_64-windows:
       url: https://github.com/starship/starship/releases/download/v1.11.0/starship-x86_64-pc-windows-msvc.zip
       sha256: b8d58ca4119dc37f3647c3018e59d1b1bbbd06cfa782ebfa9e4be3e678af0c15
+  1.12.0:
+    aarch64-linux:
+      url: https://github.com/starship/starship/releases/download/v1.12.0/starship-aarch64-unknown-linux-musl.tar.gz
+      sha256: f2b06f9b0ea2691c1b2620c63d88a8cc856d9bd4ac7047b5da6d31b14895fdb9
+    aarch64-macos:
+      url: https://github.com/starship/starship/releases/download/v1.12.0/starship-aarch64-apple-darwin.tar.gz
+      sha256: d8da9432a1e7f44d2d2f49f9e67213bf865e6cbe7b50952365ed750444b0cf3f
+    aarch64-windows:
+      url: https://github.com/starship/starship/releases/download/v1.12.0/starship-aarch64-pc-windows-msvc.zip
+      sha256: 38cd85fe3c0b170eba5b67b789a03a0838805edeec74b10aed0f550d72d86eca
+    x86-linux:
+      url: https://github.com/starship/starship/releases/download/v1.12.0/starship-i686-unknown-linux-musl.tar.gz
+      sha256: 0fd83a31b93055ba288b48d20e2f63beb4e6b14b744cb2980075fca54ce99168
+    x86-windows:
+      url: https://github.com/starship/starship/releases/download/v1.12.0/starship-i686-pc-windows-msvc.zip
+      sha256: cad49eeca6f0dc7ae99752bf92916ff04f2bf28b10ea12f05d53f7f7baf402f7
+    x86_64-linux:
+      url: https://github.com/starship/starship/releases/download/v1.12.0/starship-x86_64-unknown-linux-musl.tar.gz
+      sha256: a09fd1788fbafcb2a493a5da369e7b903e3d06584d6ed6ba3086a2de29105c70
+    x86_64-macos:
+      url: https://github.com/starship/starship/releases/download/v1.12.0/starship-x86_64-apple-darwin.tar.gz
+      sha256: b4cbe4e8a72f6eb2c4f132d306b00b6d742314bb4cc4e9e43cd1a9cc8357ac53
+    x86_64-windows:
+      url: https://github.com/starship/starship/releases/download/v1.12.0/starship-x86_64-pc-windows-msvc.zip
+      sha256: 8e265de431c96f32566b384760fea25f75c567364c3e43d7355d56ae13930d47
   1.9.1:
     x86_64-linux:
       url: https://github.com/starship/starship/releases/download/v1.9.1/starship-x86_64-unknown-linux-gnu.tar.gz
@@ -88,3 +112,6 @@ installs:
     any-any:
       files:
         starship${exe_ext}: bin/
+      tests:
+      - starship${exe_ext} --version
+fetcher: Auto

--- a/syncthing.yaml
+++ b/syncthing.yaml
@@ -1,6 +1,5 @@
 name: syncthing
-description: Syncthing is a continuous file synchronization program. It synchronizes
-  files between two or more computers in real time, safely protected from prying eyes.
+description: Syncthing is a continuous file synchronization program. It synchronizes files between two or more computers in real time, safely protected from prying eyes.
 homepage: https://syncthing.net
 repository: https://github.com/syncthing/syncthing
 releases:
@@ -138,6 +137,34 @@ releases:
     x86_64-windows:
       url: https://github.com/syncthing/syncthing/releases/download/v1.22.1/syncthing-windows-amd64-v1.22.1.zip
       sha256: e191f58c444d1a2b5aa8d7aeaf28503077c35d77f3ecf1e2054397bc3007d9d9
+  1.22.2:
+    aarch64-linux:
+      url: https://github.com/syncthing/syncthing/releases/download/v1.22.2/syncthing-linux-arm64-v1.22.2.tar.gz
+      sha256: 10993458ca1982f11c2e9d52f4fae3374192976e89ae905c47a76bfc0bf1524a
+    aarch64-macos:
+      url: https://github.com/syncthing/syncthing/releases/download/v1.22.2/syncthing-macos-arm64-v1.22.2.zip
+      sha256: 38f8634a0005092602dade693bcaed6e98520fe859fb415c4c74c58b79ee3e60
+    aarch64-windows:
+      url: https://github.com/syncthing/syncthing/releases/download/v1.22.2/syncthing-windows-arm64-v1.22.2.zip
+      sha256: 43335440ee137f16186858cf58d819b08c66b9bb5ee41035c7b4929e75c479d0
+    any-macos:
+      url: https://github.com/syncthing/syncthing/releases/download/v1.22.2/syncthing-macos-universal-v1.22.2.zip
+      sha256: 809cbc963bd03de7a26a380a9d16ab8ba18c5ee2bb4a7d6698de26e60c4e2fbb
+    x86-linux:
+      url: https://github.com/syncthing/syncthing/releases/download/v1.22.2/syncthing-linux-386-v1.22.2.tar.gz
+      sha256: b2c6c1f605d35a20de17e4f4fbda929f2302a6d2b88404f764b3935dd14c9c68
+    x86-windows:
+      url: https://github.com/syncthing/syncthing/releases/download/v1.22.2/syncthing-windows-386-v1.22.2.zip
+      sha256: 3453b888efc354c92762ff8ac98cab2908b822a14114441cb6e002a223148560
+    x86_64-linux:
+      url: https://github.com/syncthing/syncthing/releases/download/v1.22.2/syncthing-linux-amd64-v1.22.2.tar.gz
+      sha256: 72077006e97097a9f3bec3fba866f682018de383797114b94218519c9bc65927
+    x86_64-macos:
+      url: https://github.com/syncthing/syncthing/releases/download/v1.22.2/syncthing-macos-amd64-v1.22.2.zip
+      sha256: d84d3f7376ebc791f2763731de0e22fe299eb0318e77e780fdfc2c34ef805881
+    x86_64-windows:
+      url: https://github.com/syncthing/syncthing/releases/download/v1.22.2/syncthing-windows-amd64-v1.22.2.zip
+      sha256: d7fab2da5687609d8b5feb5c3278790eaa4a3c148e46567b08c4c8329cc82c3a
 installs:
   1.20.3:
     any-any:
@@ -158,3 +185,5 @@ installs:
         README.txt: ${doc_dir}
         etc: ${doc_dir}
         syncthing${exe_ext}: bin/
+      tests:
+      - syncthing${exe_ext} --version

--- a/wtfutil.yaml
+++ b/wtfutil.yaml
@@ -38,3 +38,5 @@ installs:
         LICENSE.md: ${doc_dir}
         README.md: ${doc_dir}
         wtfutil${exe_ext}: bin/
+      tests:
+        - wtfutil${exe_ext} --version

--- a/xh.yaml
+++ b/xh.yaml
@@ -39,4 +39,5 @@ installs:
         doc/CHANGELOG.md: ${doc_dir}
         doc/xh.1: share/man/man1/
         xh${exe_ext}: bin/
-      extra_files: {}
+      tests:
+        - xh${exe_ext} --version

--- a/xsv.yaml
+++ b/xsv.yaml
@@ -24,3 +24,5 @@ installs:
     any-any:
       files:
         xsv${exe_ext}: bin/
+      tests:
+        - xsv${exe_ext} --version


### PR DESCRIPTION
- Update cmake
- Update clyde to 0.4.1
- Add tests
- Add test entries for almost all packages
- Update glab
- Update act
- Update datree
- Update glab
- Update hexyl
- Update nushell
- Update croc
- Update fd
- Update hexyl
- Update syncthing
- Update changie
- Update glab
- Update starship
- Add icoutils package
- ci/check-packages: add a --dry-run option
- ci/check-packages: add support for dir-based packages
- Package ninja
