### PR TITLE
Fix vault macOS binaries not passing CI anymore

### DIFF
--- a/vault.yaml
+++ b/vault.yaml
@@ -9,7 +9,7 @@ releases:
       sha256: 7b35d12518729cfe3efe2007a07862934b0a6df053146ea15243f89e6b0bfbf2
     aarch64-macos:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_darwin_arm64.zip
-      sha256: f1fa420858eb8674416a2285cb48f9887c680eb3437235cc06c69a30178de708
+      sha256: 24dc14e1492cea39442ff8754ffed4b58e9d703342f8c93fa61b5006a4b4c568
     x86-linux:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_linux_386.zip
       sha256: a28e1093b1a289634280710dcaf11acba3aad4572bee9c4dd3a614fecee89a66
@@ -21,7 +21,7 @@ releases:
       sha256: 116c143de377a77a7ea455a367d5e9fe5290458e8a941a6e2dd85d92aaedba67
     x86_64-macos:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_darwin_amd64.zip
-      sha256: 76d985c42a254bf16fa55fbf39092a34e27aba22942c2f829a6ce81ac5fdc40f
+      sha256: d1ff82c1fc192f027eb5ba81ebaa519166037c53faa43cc38b886678100188ef
     x86_64-windows:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_windows_amd64.zip
       sha256: 0421531b5846a45a53547bc9a505de2b11d91d0a48fdb5aed1d77259720db5ab


### PR DESCRIPTION
Vault macOS binaries have been re-signed, so we need to update their checksum.

https://support.hashicorp.com/hc/en-us/articles/13177506317203
