### PR TITLE
upmerge main

### DIFF
--- a/act.yaml
+++ b/act.yaml
@@ -179,6 +179,56 @@ releases:
     x86_64-windows:
       url: https://github.com/nektos/act/releases/download/v0.2.35/act_Windows_x86_64.zip
       sha256: 150162997bd4c4fee84d1f1384975c0ebb06490f0d2bb6cdb96129112bf8b3ad
+  0.2.40:
+    aarch64-linux:
+      url: https://github.com/nektos/act/releases/download/v0.2.40/act_Linux_arm64.tar.gz
+      sha256: f9cc499c7110f8ceb9b9da1f0f9236fb14475855fc42786604666f82493d7eee
+    aarch64-macos:
+      url: https://github.com/nektos/act/releases/download/v0.2.40/act_Darwin_arm64.tar.gz
+      sha256: 848bf5f96fa45cf1b9d2c945c1d86378acf9662256b23d5e87f3482c7d417fa3
+    aarch64-windows:
+      url: https://github.com/nektos/act/releases/download/v0.2.40/act_Windows_arm64.zip
+      sha256: bc6a95b82bf28668ee5553bdbe7a5da04e280f2440a52df8176d65ae4bcb849b
+    x86-linux:
+      url: https://github.com/nektos/act/releases/download/v0.2.40/act_Linux_i386.tar.gz
+      sha256: f8af896b6d73a60173ba71ba645f227583ee045b3cc84950df6e8f24093929db
+    x86-windows:
+      url: https://github.com/nektos/act/releases/download/v0.2.40/act_Windows_i386.zip
+      sha256: 5cac3749a343d7cc29e843c5692610a748459442ab616c0e2a6cd8b42defac99
+    x86_64-linux:
+      url: https://github.com/nektos/act/releases/download/v0.2.40/act_Linux_x86_64.tar.gz
+      sha256: 7db86032c267f1b0e6b8e5cd6c7a347e4b04902a908a4de2e95bf1f03ce12681
+    x86_64-macos:
+      url: https://github.com/nektos/act/releases/download/v0.2.40/act_Darwin_x86_64.tar.gz
+      sha256: 5233a48d45d5b08f4173dedd0c3717d2052cc6a13d8b4fb815768ce5d520efc8
+    x86_64-windows:
+      url: https://github.com/nektos/act/releases/download/v0.2.40/act_Windows_x86_64.zip
+      sha256: 39833df07026d443e5906fff03640162110bb259926e94a1eb83b21f53ea64a7
+  0.2.41:
+    aarch64-linux:
+      url: https://github.com/nektos/act/releases/download/v0.2.41/act_Linux_arm64.tar.gz
+      sha256: e64a2f202925d48bd28bd98a552a1cb843377c6d53894bfa509fb21e48c9d42e
+    aarch64-macos:
+      url: https://github.com/nektos/act/releases/download/v0.2.41/act_Darwin_arm64.tar.gz
+      sha256: 59de03d5f7fc2ce6135122e6c01ad72fe063d160708e87c325ba742afb9f1378
+    aarch64-windows:
+      url: https://github.com/nektos/act/releases/download/v0.2.41/act_Windows_arm64.zip
+      sha256: d56dbbf346fcc38196950ef795f7b78f6a06b9a5c2cf2c892d92d489e9ee035e
+    x86-linux:
+      url: https://github.com/nektos/act/releases/download/v0.2.41/act_Linux_i386.tar.gz
+      sha256: 0fd8a4486ef557c8112f4c306294957f8ec856632d261695a90c440d351069fa
+    x86-windows:
+      url: https://github.com/nektos/act/releases/download/v0.2.41/act_Windows_i386.zip
+      sha256: c3d7e52280c0b0ebe69184ad63f615c975643ccff2c0157382bdfa206b1ca48d
+    x86_64-linux:
+      url: https://github.com/nektos/act/releases/download/v0.2.41/act_Linux_x86_64.tar.gz
+      sha256: 0a4b3170e580cc2a0e483548242a71859c17ddb2723019c709ff274c225d9bfb
+    x86_64-macos:
+      url: https://github.com/nektos/act/releases/download/v0.2.41/act_Darwin_x86_64.tar.gz
+      sha256: c47039efa460a477dd1d406d025016b60e609c301ec2656d75979608899c06ad
+    x86_64-windows:
+      url: https://github.com/nektos/act/releases/download/v0.2.41/act_Windows_x86_64.zip
+      sha256: 74445e9f5c4130c4a00bb7404db46e2204b06e9f139f85ff7752c8b44fec7b6e
 installs:
   0.2.28:
     any-any:

--- a/changie.yaml
+++ b/changie.yaml
@@ -78,6 +78,31 @@ releases:
     x86_64-windows:
       url: https://github.com/miniscruff/changie/releases/download/v1.10.2/changie_1.10.2_windows_amd64.zip
       sha256: 1ebbbb328e951e3600172e6ab9a687f3b5487e3af8e465580b287fa40cfb3ce6
+  1.11.0:
+    aarch64-linux:
+      url: https://github.com/miniscruff/changie/releases/download/v1.11.0/changie_1.11.0_linux_arm64.tar.gz
+      sha256: ce8a1bdb7af4f78d48fd5ed7ee7632bdb39b3dda66bbf863e1786ff7426c0d08
+    aarch64-macos:
+      url: https://github.com/miniscruff/changie/releases/download/v1.11.0/changie_1.11.0_darwin_arm64.tar.gz
+      sha256: b69e262e46f59b4e5c0a1afefa92070c9790b118efca2db75a260bbe84f5d9f7
+    aarch64-windows:
+      url: https://github.com/miniscruff/changie/releases/download/v1.11.0/changie_1.11.0_windows_arm64.zip
+      sha256: 3506bffb7eb1ef2d8a830e564cbc8b3ae9bc282f91f49e251ff6ab317f1d2031
+    x86-linux:
+      url: https://github.com/miniscruff/changie/releases/download/v1.11.0/changie_1.11.0_linux_386.tar.gz
+      sha256: b836ca8ea385a43ae18393e3b4c7a84d2e6a53b61e0b22de9f3aece7308d64fe
+    x86-windows:
+      url: https://github.com/miniscruff/changie/releases/download/v1.11.0/changie_1.11.0_windows_386.zip
+      sha256: 001c970086e5553f0626ea7598004e43bcdbff62c545577457a73a8018eb9e3f
+    x86_64-linux:
+      url: https://github.com/miniscruff/changie/releases/download/v1.11.0/changie_1.11.0_linux_amd64.tar.gz
+      sha256: 00b0682ee627a5770cfd5606b6e254b5e72e197a88336c703f62432538bdc653
+    x86_64-macos:
+      url: https://github.com/miniscruff/changie/releases/download/v1.11.0/changie_1.11.0_darwin_amd64.tar.gz
+      sha256: 079a05b7b6eb3bb3141633a90669c71991c9930cf18118c0a48ba3f88023df1a
+    x86_64-windows:
+      url: https://github.com/miniscruff/changie/releases/download/v1.11.0/changie_1.11.0_windows_amd64.zip
+      sha256: 641bc084ed8b00c046143a329844a668eb0b131de3a2388b4d0bcb302f4f511c
   1.8.0:
     aarch64-linux:
       url: https://github.com/miniscruff/changie/releases/download/v1.8.0/changie_1.8.0_linux_arm64.tar.gz

--- a/ci/check-packages
+++ b/ci/check-packages
@@ -3,106 +3,29 @@
 Check packages are valid
 """
 import argparse
-import json
-import os
-import platform
 import random
 import re
-import shutil
 import subprocess
 import sys
 
 from pathlib import Path
-from typing import BinaryIO, Dict, List
-from urllib import request
+from typing import List
 
-if sys.stdout.isatty():
-    CYAN = "\033[36m"
-    RESET = "\033[0;0m"
-else:
-    CYAN = ""
-    RESET = ""
-
-CLYDE_SNAPSHOT_LIST_URL = "https://builds.agateau.com/clyde/"
-CLYDE_RELEASE_LIST_URL = "https://api.github.com/repos/agateau/clyde/releases/latest"
-
-CLYDE_ARCHIVE_NAME = ""
-CLYDE_ARCHIVE_RX = ""
-OS_NAME = ""
-
-GITHUB_TOKEN = os.getenv("CLYDE_GITHUB_TOKEN", "")
+from get_clyde import find_clyde_snapshot_url, find_clyde_release_url, download_clyde, GITHUB_TOKEN
+from tui import eprint, progress
+from utils import which
 
 CI_DIR = Path(__file__).parent.resolve()
 CLYDE_DIR = CI_DIR / "clyde"
 ROOT_DIR = CI_DIR.parent.resolve()
 
-CURL_RETRY = 3
-
 RANDOM_COUNT = 8
-
-
-def init_os_globals() -> None:
-    global CLYDE_ARCHIVE_NAME
-    global CLYDE_ARCHIVE_RX
-    global OS_NAME
-    system = platform.system()
-
-    if system == "Linux":
-        OS_NAME = "linux"
-    elif system == "Darwin":
-        OS_NAME = "macos"
-    elif system == "Windows":
-        OS_NAME = "windows"
-    else:
-        sys.exit(f"Unknown system {system}")
-
-    if OS_NAME == "windows":
-        archive_ext_rx = r"\.zip"
-        CLYDE_ARCHIVE_NAME = "clyde.zip"
-    else:
-        archive_ext_rx = r"\.tar\.gz"
-        CLYDE_ARCHIVE_NAME = "clyde.tar.gz"
-    CLYDE_ARCHIVE_RX = f"clyde-[-_a-zT0-9.+]*-{OS_NAME}{archive_ext_rx}"
 
 
 def check_github_token() -> None:
     if not GITHUB_TOKEN:
-        eprint(f"CLYDE_GITHUB_TOKEN environment variable not set. Consider defining it"
+        eprint("CLYDE_GITHUB_TOKEN environment variable not set. Consider defining it"
                " to avoid being rate-limited.")
-
-
-def create_request(url: str, headers: Dict[str, str]) -> request.Request:
-    req = request.Request(url)
-    for key, value in headers.items():
-        req.add_header(key, value)
-
-    return req
-
-
-def eprint(msg: str) -> None:
-    print(msg, file=sys.stderr)
-
-
-def http_get(url: str) -> BinaryIO:
-    eprint(f"http_get {url}")
-    headers = {
-        "User-Agent": "clyde-store-check-packages",
-    }
-    if GITHUB_TOKEN:
-        headers["Authorization"] = f"Bearer {GITHUB_TOKEN}"
-    req = create_request(url, headers)
-    return request.urlopen(req)  # type: ignore
-
-
-def progress(msg: str) -> None:
-    eprint(f"{CYAN}{msg}{RESET}")
-
-
-def which(cmd: str) -> str:
-    cmd_path = shutil.which(cmd)
-    if cmd_path is None:
-        sys.exit(f"Can't find {cmd} in {os.environ['PATH']}")
-    return cmd_path
 
 
 def list_modified_files(target: str) -> List[Path]:
@@ -142,50 +65,6 @@ def list_packages_to_check(target: str) -> List[Path]:
     return packages
 
 
-def find_clyde_release_url() -> str:
-    progress("Looking for archive of latest Clyde release")
-    response = http_get(CLYDE_RELEASE_LIST_URL)
-    dct = json.load(response)
-    archives_url = [x["browser_download_url"] for x in dct["assets"]]
-    for url in archives_url:
-        if re.search(CLYDE_ARCHIVE_RX, url):
-            assert isinstance(url, str)
-            return url
-    sys.exit(f"Can't find URL from\n{json.dumps(dct, indent=2)}")
-
-
-def find_clyde_snapshot_url() -> str:
-    progress(f"Looking for snapshot Clyde archive on {CLYDE_SNAPSHOT_LIST_URL}")
-    content = str(http_get(CLYDE_SNAPSHOT_LIST_URL).read())
-    match = re.search(CLYDE_ARCHIVE_RX, content)
-    if not match:
-        sys.exit("Could not find archive")
-    archive_name = match.group(0)
-
-    return f"{CLYDE_SNAPSHOT_LIST_URL}{archive_name}"
-
-
-def download_clyde(url: str) -> None:
-    if CLYDE_DIR.exists():
-        shutil.rmtree(CLYDE_DIR)
-    CLYDE_DIR.mkdir()
-
-    archive_path = CLYDE_DIR / CLYDE_ARCHIVE_NAME
-    progress(f"Downloading archive from {url}")
-    subprocess.run([which("curl"), "--retry", str(CURL_RETRY), "-L", url,
-                    "-o", str(archive_path)],
-                   check=True)
-
-    progress("Unpacking archive")
-    if OS_NAME == "windows":
-        cmd = [which("7z"), "e", "-bb0", str(archive_path)]
-    else:
-        cmd = [which("tar"), "--strip-components=1", "-xzf", str(archive_path)]
-    subprocess.run(cmd, check=True, cwd=CLYDE_DIR)
-
-    os.environ["PATH"] = str(CLYDE_DIR) + os.pathsep + os.environ["PATH"]
-
-
 def check_packages(packages: List[Path]) -> int:
     # We must run the test in the current directory for now
     package_names = [x.relative_to(ROOT_DIR) for x in packages]
@@ -205,7 +84,6 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    init_os_globals()
     check_github_token()
 
     if args.all:
@@ -229,7 +107,7 @@ def main() -> int:
     else:
         clyde_url = find_clyde_snapshot_url()
 
-    download_clyde(clyde_url)
+    download_clyde(clyde_url, CLYDE_DIR)
     return check_packages(packages)
 
     return 0

--- a/ci/fetch
+++ b/ci/fetch
@@ -8,7 +8,11 @@ import subprocess
 import sys
 
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Iterable, List
+
+from get_clyde import find_clyde_snapshot_url, download_clyde
+from tui import progress, warning
 
 
 def run_git(args: List[str], capture_output: bool = False) -> subprocess.CompletedProcess:
@@ -24,7 +28,7 @@ def get_modified_packages() -> Iterable[str]:
                 yield path
 
 
-def file_pr(package_file: str):
+def file_pr(package_file: str, base_branch: str):
     path = Path(package_file)
     name = path.stem
     if name == "index":
@@ -32,14 +36,15 @@ def file_pr(package_file: str):
 
     branch_name = f"update-{name}"
     try:
+        run_git(["checkout", base_branch])
         run_git(["checkout", "-b", branch_name])
     except subprocess.CalledProcessError:
-        print(f"Failed to create branch '{branch_name}', check it does not already exist")
+        warning(f"Failed to create branch '{branch_name}', check it does not already exist.")
         return
     run_git(["add", package_file])
     run_git(["commit", "-m", f"Update {name}"])
     run_git(["push", "-u", "origin", branch_name])
-    subprocess.run(["gh", "pr", "create", "--fill"], check=True)
+    subprocess.run(["gh", "pr", "create", "--fill", "--base", base_branch], check=True)
     subprocess.run(["gh", "pr", "merge", "--auto", "-dm"], check=True)
     run_git(["checkout", "-"])
 
@@ -59,6 +64,12 @@ def main():
     )
 
     parser.add_argument(
+        "--next",
+        action="store_true",
+        help="Target 'next' instead of 'main'",
+    )
+
+    parser.add_argument(
         "--only-pr",
         action="store_true",
         help="Files PRs for modified packages, do not fetch updates",
@@ -71,11 +82,18 @@ def main():
     args = parser.parse_args()
 
     if not args.only_pr:
-        subprocess.run(["clydetools", "fetch"] + args.package_files, check=True)
+        with TemporaryDirectory() as temp_dir:
+            clyde_dir = Path(temp_dir) / "clyde"
+            clyde_url = find_clyde_snapshot_url()
+            download_clyde(clyde_url, clyde_dir)
 
+            package_files = [Path(x).absolute() for x in args.package_files]
+            subprocess.run(["clydetools", "fetch"] + package_files, check=True, cwd=temp_dir)
+
+    base_branch = "next" if args.next else "main"
     for package in get_modified_packages():
-        print(f"Filing PR for {package}")
-        file_pr(package)
+        progress(f"Filing PR for {package}")
+        file_pr(package, base_branch)
 
     return 0
 

--- a/ci/get_clyde.py
+++ b/ci/get_clyde.py
@@ -1,0 +1,100 @@
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+from pathlib import Path
+from typing import BinaryIO, Dict, Pattern
+from urllib import request
+
+from tui import eprint, progress
+from utils import IS_MACOS, IS_WINDOWS, which
+
+GITHUB_TOKEN = os.getenv("CLYDE_GITHUB_TOKEN", "")
+
+CLYDE_SNAPSHOT_LIST_URL = "https://builds.agateau.com/clyde/"
+CLYDE_RELEASE_LIST_URL = "https://api.github.com/repos/agateau/clyde/releases/latest"
+
+CURL_RETRY = 3
+
+
+def _create_request(url: str, headers: Dict[str, str]) -> request.Request:
+    req = request.Request(url)
+    for key, value in headers.items():
+        req.add_header(key, value)
+
+    return req
+
+
+def _http_get(url: str) -> BinaryIO:
+    eprint(f"get {url}")
+    headers = {
+        "User-Agent": "clyde-store-check-packages",
+    }
+    if GITHUB_TOKEN:
+        headers["Authorization"] = f"Bearer {GITHUB_TOKEN}"
+    req = _create_request(url, headers)
+    return request.urlopen(req)  # type: ignore
+
+
+def _get_archive_rx() -> Pattern[str]:
+    if IS_WINDOWS:
+        archive_ext_rx = r"\.zip"
+    else:
+        archive_ext_rx = r"\.tar\.gz"
+
+    if IS_WINDOWS:
+        os_name = "windows"
+    elif IS_MACOS:
+        os_name = "macos"
+    else:
+        os_name = "linux"
+
+    return re.compile(f"clyde-[-_a-zT0-9.+]*-{os_name}{archive_ext_rx}")
+
+
+def find_clyde_release_url() -> str:
+    progress("Looking for archive of latest Clyde release")
+    response = _http_get(CLYDE_RELEASE_LIST_URL)
+    dct = json.load(response)
+    archives_url = [x["browser_download_url"] for x in dct["assets"]]
+    archive_rx = _get_archive_rx()
+    for url in archives_url:
+        if archive_rx.search(url):
+            assert isinstance(url, str)
+            return url
+    sys.exit(f"Can't find URL from\n{json.dumps(dct, indent=2)}")
+
+
+def find_clyde_snapshot_url() -> str:
+    progress(f"Looking for snapshot Clyde archive on {CLYDE_SNAPSHOT_LIST_URL}")
+    content = str(_http_get(CLYDE_SNAPSHOT_LIST_URL).read())
+    match = _get_archive_rx().search(content)
+    if not match:
+        sys.exit("Could not find archive")
+    archive_name = match.group(0)
+
+    return f"{CLYDE_SNAPSHOT_LIST_URL}{archive_name}"
+
+
+def download_clyde(url: str, clyde_dir: Path) -> None:
+    if clyde_dir.exists():
+        shutil.rmtree(clyde_dir)
+    clyde_dir.mkdir()
+
+    archive_path = clyde_dir / ("clyde.zip" if IS_WINDOWS else "clyde.tar.gz")
+    progress(f"Downloading archive from {url}")
+    subprocess.run([which("curl"), "--retry", str(CURL_RETRY), "-L", url,
+                    "-o", str(archive_path)],
+                   check=True)
+
+    progress("Unpacking archive")
+    if IS_WINDOWS:
+        cmd = [which("7z"), "e", "-bb0", str(archive_path)]
+    else:
+        cmd = [which("tar"), "--strip-components=1", "-xzf", str(archive_path)]
+    subprocess.run(cmd, check=True, cwd=clyde_dir)
+
+    os.environ["PATH"] = str(clyde_dir) + os.pathsep + os.environ["PATH"]

--- a/ci/tui.py
+++ b/ci/tui.py
@@ -1,0 +1,23 @@
+import sys
+
+
+if sys.stdout.isatty():
+    ORANGE = "\033[33m"
+    CYAN = "\033[36m"
+    RESET = "\033[0;0m"
+else:
+    ORANGE = ""
+    CYAN = ""
+    RESET = ""
+
+
+def eprint(msg: str) -> None:
+    print(msg, file=sys.stderr)
+
+
+def progress(msg: str) -> None:
+    eprint(f"{CYAN}{msg}{RESET}")
+
+
+def warning(msg: str) -> None:
+    eprint(f"{ORANGE}{msg}{RESET}")

--- a/ci/utils.py
+++ b/ci/utils.py
@@ -1,0 +1,16 @@
+import os
+import platform
+import shutil
+import sys
+
+
+IS_WINDOWS = platform.system() == "Windows"
+IS_LINUX = platform.system() == "Linux"
+IS_MACOS = platform.system() == "Darwin"
+
+
+def which(cmd: str) -> str:
+    cmd_path = shutil.which(cmd)
+    if cmd_path is None:
+        sys.exit(f"Can't find {cmd} in {os.environ['PATH']}")
+    return cmd_path

--- a/cmake.yaml
+++ b/cmake.yaml
@@ -276,6 +276,25 @@ releases:
     x86_64-windows:
       url: https://github.com/Kitware/CMake/releases/download/v3.25.1/cmake-3.25.1-windows-x86_64.zip
       sha256: d93958d87cc9b91983489f0b37a268b03a3c891894d11f5437fa2a5ce94aab24
+  3.25.2:
+    aarch64-linux:
+      url: https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-aarch64.tar.gz
+      sha256: 9216ecf0449ade700e66e0def11eeaebf9fa7d4428c02f49cb59f11418d3f8a5
+    aarch64-windows:
+      url: https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-windows-arm64.zip
+      sha256: c54fb253ae184b391d5366b958c38b282d5f9b6a5854643c28e6887f5fd92590
+    any-macos:
+      url: https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-macos-universal.tar.gz
+      sha256: 0b5def3f77617b2ce0ec6701f96e4123a7b14bd0b8a5674ab0556c364ff7cb52
+    x86-windows:
+      url: https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-windows-i386.zip
+      sha256: 833abaa21bb673491def058cc38834fbd606d525ab271f37a3b8a3aed586c4a0
+    x86_64-linux:
+      url: https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-linux-x86_64.tar.gz
+      sha256: 783da74f132fd1fea91b8236d267efa4df5b91c5eec1dea0a87f0cf233748d99
+    x86_64-windows:
+      url: https://github.com/Kitware/CMake/releases/download/v3.25.2/cmake-3.25.2-windows-x86_64.zip
+      sha256: 0db9d3cebf894f64751141253fb9d9e310f325e2e03044f61249a359d6adf301
 installs:
   3.20.0:
     any-any:
@@ -322,3 +341,4 @@ installs:
       - cmake-gui.exe --version
       - cpack.exe --version
       - ctest.exe --version
+fetcher: Auto

--- a/d2.yaml
+++ b/d2.yaml
@@ -60,6 +60,44 @@ releases:
     x86_64-windows:
       url: https://github.com/terrastruct/d2/releases/download/v0.1.4/d2-v0.1.4-windows-amd64.tar.gz
       sha256: e5265be1797b539b6c4bd2b5d78c59a1dcf5cecd860790979b9e8870a794f6f2
+  0.1.5:
+    aarch64-linux:
+      url: https://github.com/terrastruct/d2/releases/download/v0.1.5/d2-v0.1.5-linux-arm64.tar.gz
+      sha256: 5ca69f04c231bc8c0e662ac885814ee698a86086db19154fdd72f970f400226a
+    aarch64-macos:
+      url: https://github.com/terrastruct/d2/releases/download/v0.1.5/d2-v0.1.5-macos-arm64.tar.gz
+      sha256: aae6af7aff28fdbd06ff8f7f56f93cda0e8a0120939f3fed5cfda0f1b4db44a2
+    aarch64-windows:
+      url: https://github.com/terrastruct/d2/releases/download/v0.1.5/d2-v0.1.5-windows-arm64.tar.gz
+      sha256: a16e798014a91b2dd6e757540307bc82b8b68cf6c407e04ccba0f7be4601424f
+    x86_64-linux:
+      url: https://github.com/terrastruct/d2/releases/download/v0.1.5/d2-v0.1.5-linux-amd64.tar.gz
+      sha256: 41050df02f4be53a042a0d0ce8ea8a35bfef68178ebe61e62ba9e5efba97b8b1
+    x86_64-macos:
+      url: https://github.com/terrastruct/d2/releases/download/v0.1.5/d2-v0.1.5-macos-amd64.tar.gz
+      sha256: aea1a8ed1105b0f9bf48b43556c2f64d8b963bde5f4afc3537ac5594c7468a3a
+    x86_64-windows:
+      url: https://github.com/terrastruct/d2/releases/download/v0.1.5/d2-v0.1.5-windows-amd64.tar.gz
+      sha256: d27b275f1600c297e18c94bf9cbafcc4b12933d34d9765aee99665eee8be5d09
+  0.1.6:
+    aarch64-linux:
+      url: https://github.com/terrastruct/d2/releases/download/v0.1.6/d2-v0.1.6-linux-arm64.tar.gz
+      sha256: 5c2516505f992e0e427f0172ba5214960b27e1c8ac9f8af74958c04050c1b98a
+    aarch64-macos:
+      url: https://github.com/terrastruct/d2/releases/download/v0.1.6/d2-v0.1.6-macos-arm64.tar.gz
+      sha256: 0360b7b8f073b4c3c851acc04ceafdd7378bf40175d59b9f966c059dcb7276e0
+    aarch64-windows:
+      url: https://github.com/terrastruct/d2/releases/download/v0.1.6/d2-v0.1.6-windows-arm64.tar.gz
+      sha256: 7116c3eba0cbd5bbb0828e401d202adb692e8454bcfbce513d219589d5488a29
+    x86_64-linux:
+      url: https://github.com/terrastruct/d2/releases/download/v0.1.6/d2-v0.1.6-linux-amd64.tar.gz
+      sha256: 750941b76cd27881f229e278a569e76c17d7235a40e07bee2e8cfa164686142c
+    x86_64-macos:
+      url: https://github.com/terrastruct/d2/releases/download/v0.1.6/d2-v0.1.6-macos-amd64.tar.gz
+      sha256: 7d8f4f6c651842c421e04a780214f4b681bfd931e058c68ed510e2e1b3c828ef
+    x86_64-windows:
+      url: https://github.com/terrastruct/d2/releases/download/v0.1.6/d2-v0.1.6-windows-amd64.tar.gz
+      sha256: 81e21bfb4419d2068a57460af945d81f7bd1828fab812cfc2ba7256f241ca204
 installs:
   0.1.2:
     any-any:

--- a/datree.yaml
+++ b/datree.yaml
@@ -845,6 +845,72 @@ releases:
     x86_64-windows:
       url: https://github.com/datreeio/datree/releases/download/1.8.12/datree-cli_1.8.12_windows_x86_64.zip
       sha256: 530044db09d12f8ea9116129fb4303a47f2de31c8b2a1c8cf85c9af520cae32c
+  1.8.14:
+    aarch64-linux:
+      url: https://github.com/datreeio/datree/releases/download/1.8.14/datree-cli_1.8.14_Linux_arm64.zip
+      sha256: 98c6af8113eeb654ded74940b70df65ca2c11183f3d52a934ffcb0ba3b18a9f4
+    aarch64-macos:
+      url: https://github.com/datreeio/datree/releases/download/1.8.14/datree-cli_1.8.14_Darwin_arm64.zip
+      sha256: 7dd3e715edac52a0e38639920ecb9e17177d1e9c20ced746f094a4b39d178627
+    x86-linux:
+      url: https://github.com/datreeio/datree/releases/download/1.8.14/datree-cli_1.8.14_Linux_386.zip
+      sha256: deb7d7b1ebbb6d575c7078ec7ec44a0b32384cdb82bb26f443302291272a1f61
+    x86-windows:
+      url: https://github.com/datreeio/datree/releases/download/1.8.14/datree-cli_1.8.14_windows_386.zip
+      sha256: 69257044178d98d5c8ac5bdcbc9cd7f9123232a8f6e7a49536f5439791009b71
+    x86_64-linux:
+      url: https://github.com/datreeio/datree/releases/download/1.8.14/datree-cli_1.8.14_Linux_x86_64.zip
+      sha256: ad177bc3c7f5732eb33d819741dea44243315a712bb2d53ff6a6842a7683dff1
+    x86_64-macos:
+      url: https://github.com/datreeio/datree/releases/download/1.8.14/datree-cli_1.8.14_Darwin_x86_64.zip
+      sha256: 400b880cdaba5c33ee5915a950df18c6210086074b765a13239fe486e2cddbb5
+    x86_64-windows:
+      url: https://github.com/datreeio/datree/releases/download/1.8.14/datree-cli_1.8.14_windows_x86_64.zip
+      sha256: 859508f8028d1a03807de876c5233a82142136ce6cf5ffde2cb8f52e7362e4ab
+  1.8.20:
+    aarch64-linux:
+      url: https://github.com/datreeio/datree/releases/download/1.8.20/datree-cli_1.8.20_Linux_arm64.zip
+      sha256: b8987ae4333741aa93b6691fd9d0ca91ad8a331880aa174cc745306d0f560beb
+    aarch64-macos:
+      url: https://github.com/datreeio/datree/releases/download/1.8.20/datree-cli_1.8.20_Darwin_arm64.zip
+      sha256: 8514c633dd73565e9c7d31116bc04df6ed704ee843b30fdc9a0810114cb3948d
+    x86-linux:
+      url: https://github.com/datreeio/datree/releases/download/1.8.20/datree-cli_1.8.20_Linux_386.zip
+      sha256: 07db04d0c60feabed5a1ddff3ebd6c6184ac351f29b2b61ef24f2b34a5ff4efc
+    x86-windows:
+      url: https://github.com/datreeio/datree/releases/download/1.8.20/datree-cli_1.8.20_windows_386.zip
+      sha256: 5d84d78a42886eec4dbd4df532069d6846cc7c9ee28d56ae860c93c317c74bbb
+    x86_64-linux:
+      url: https://github.com/datreeio/datree/releases/download/1.8.20/datree-cli_1.8.20_Linux_x86_64.zip
+      sha256: c5aec00bc2590bf577f7ebd17983b5f2936febd8344ab3acdd6e85319298c33f
+    x86_64-macos:
+      url: https://github.com/datreeio/datree/releases/download/1.8.20/datree-cli_1.8.20_Darwin_x86_64.zip
+      sha256: 57567a6587ad12f85eb53bb4615b1b4cc648a8bf5de0e156a552cd6a01aafd5d
+    x86_64-windows:
+      url: https://github.com/datreeio/datree/releases/download/1.8.20/datree-cli_1.8.20_windows_x86_64.zip
+      sha256: f7c78dab4d6e15a17f01ae2cdbf28b32fbb1f1f7c0c260c06e4d04be63087b33
+  1.8.21:
+    aarch64-linux:
+      url: https://github.com/datreeio/datree/releases/download/1.8.21/datree-cli_1.8.21_Linux_arm64.zip
+      sha256: ea5bde426051a767d34c8bcfc2159679b4b187fba99b41d6da160e897b3a0d95
+    aarch64-macos:
+      url: https://github.com/datreeio/datree/releases/download/1.8.21/datree-cli_1.8.21_Darwin_arm64.zip
+      sha256: a6ec15ba4ccf1bd55eccb56c899f5243c0a50b711dd42f43cf3c4b2d3a5cda43
+    x86-linux:
+      url: https://github.com/datreeio/datree/releases/download/1.8.21/datree-cli_1.8.21_Linux_386.zip
+      sha256: b621720bc2e0dddc7432ddd9406a44e682094d6297633d07dbdcf4a4dac05079
+    x86-windows:
+      url: https://github.com/datreeio/datree/releases/download/1.8.21/datree-cli_1.8.21_windows_386.zip
+      sha256: efb27ba53bc2dfc5ccf8c5f2f71fa67b7d0fd2824f32f3fa075ae9cf47575fbc
+    x86_64-linux:
+      url: https://github.com/datreeio/datree/releases/download/1.8.21/datree-cli_1.8.21_Linux_x86_64.zip
+      sha256: da153be605f74778dc9efaa0b517b3f6042271aa6414234492adcc8ce58ea8ad
+    x86_64-macos:
+      url: https://github.com/datreeio/datree/releases/download/1.8.21/datree-cli_1.8.21_Darwin_x86_64.zip
+      sha256: 0d81ba4c510b8f631f27da58693e6b533bb322a5204419c24e5609728cfc1f76
+    x86_64-windows:
+      url: https://github.com/datreeio/datree/releases/download/1.8.21/datree-cli_1.8.21_windows_x86_64.zip
+      sha256: f2d697dcd8846173d79cb85ef80bacbbf90fb2ad855612ec9522924cc2c00fbc
   1.8.8:
     aarch64-linux:
       url: https://github.com/datreeio/datree/releases/download/1.8.8/datree-cli_1.8.8_Linux_arm64.zip

--- a/difftastic.yaml
+++ b/difftastic.yaml
@@ -97,6 +97,26 @@ releases:
     x86_64-windows:
       url: https://github.com/Wilfred/difftastic/releases/download/0.40.0/difft-x86_64-pc-windows-msvc.zip
       sha256: c1e4ad14017c70cbbab95ab810dfcae8420f668e8f4f56793f57565e8d490138
+  0.41.0:
+    x86_64-linux:
+      url: https://github.com/Wilfred/difftastic/releases/download/0.41.0/difft-x86_64-unknown-linux-gnu.tar.gz
+      sha256: 5b0fc011feeaeb6689d7956f4e2342b06670e108af7c466701d8c2ed296cbbef
+    x86_64-macos:
+      url: https://github.com/Wilfred/difftastic/releases/download/0.41.0/difft-x86_64-apple-darwin.tar.gz
+      sha256: f00f9d7998a5678270a64f6c0362f2f0529f7f1fedebe52bc035b5b3b971ea7f
+    x86_64-windows:
+      url: https://github.com/Wilfred/difftastic/releases/download/0.41.0/difft-x86_64-pc-windows-msvc.zip
+      sha256: 9a5c91b952b78409c89c2b76029b3e9cb0890c6dd8deba1d71841d20f86d4112
+  0.42.0:
+    x86_64-linux:
+      url: https://github.com/Wilfred/difftastic/releases/download/0.42.0/difft-x86_64-unknown-linux-gnu.tar.gz
+      sha256: 6c27fa48ce963ee45553ffe78fce50dd9b8d85bfbc98a970639215c92f4ebc23
+    x86_64-macos:
+      url: https://github.com/Wilfred/difftastic/releases/download/0.42.0/difft-x86_64-apple-darwin.tar.gz
+      sha256: 5495f933b9e441c70b26d19e992799e1edd5e59798f77088b9fa3869821192ac
+    x86_64-windows:
+      url: https://github.com/Wilfred/difftastic/releases/download/0.42.0/difft-x86_64-pc-windows-msvc.zip
+      sha256: aa45d045883644a2e817394a42041f5be4aebc1a58f87dbdf2f65d690f71f2d9
 installs:
   0.29.0:
     any-any:

--- a/dive.yaml
+++ b/dive.yaml
@@ -1,0 +1,30 @@
+name: dive
+description: A tool for exploring each layer in a docker image
+homepage: https://github.com/wagoodman/dive
+repository: https://github.com/wagoodman/dive
+releases:
+  0.0.0:
+    any-any:
+      url: https://pkg.example.com/download/pkg
+      sha256: '0'
+  0.10.0:
+    x86_64-linux:
+      url: https://github.com/wagoodman/dive/releases/download/v0.10.0/dive_0.10.0_linux_amd64.tar.gz
+      sha256: 9541997876d4985de66d0fa5924dac72258a3094ef7d3f6ef5fa5dcf6f6a47ad
+    x86_64-macos:
+      url: https://github.com/wagoodman/dive/releases/download/v0.10.0/dive_0.10.0_darwin_amd64.tar.gz
+      sha256: b4cad081146defcb90b418215cdfdf835372abd4adf1b0f33aaf1ea5d9bb3244
+    x86_64-windows:
+      url: https://github.com/wagoodman/dive/releases/download/v0.10.0/dive_0.10.0_windows_amd64.zip
+      sha256: e88cf463b48d9edc22f71b63d43f076826f32f6777ac9a8d288dd3dd8f0599e3
+installs:
+  0.0.0:
+    any-any:
+      files:
+        dive${exe_ext}: bin/
+        README.md: ${doc_dir}
+        LICENSE: ${doc_dir}
+tests:
+  0.0.0:
+    any:
+      - dive${exe_ext} --version

--- a/fzf.yaml
+++ b/fzf.yaml
@@ -207,10 +207,49 @@ releases:
     x86_64-windows:
       url: https://github.com/junegunn/fzf/releases/download/0.35.1/fzf-0.35.1-windows_amd64.zip
       sha256: 621e37dfb2338f021632ab819fe5479d56f912bf642db6bc242f59443d143d32
+  0.36.0:
+    aarch64-linux:
+      url: https://github.com/junegunn/fzf/releases/download/0.36.0/fzf-0.36.0-linux_arm64.tar.gz
+      sha256: a6e35dbc62ab9362b20d2715f022e1c24087bbd21fbe86c0185a63df3618be45
+    aarch64-macos:
+      url: https://github.com/junegunn/fzf/releases/download/0.36.0/fzf-0.36.0-darwin_arm64.zip
+      sha256: 12106a071ada73eb986869cbddec70ebbf5845ad38884b682ecc0e9b8bb3c5b0
+    aarch64-windows:
+      url: https://github.com/junegunn/fzf/releases/download/0.36.0/fzf-0.36.0-windows_arm64.zip
+      sha256: 69c41f7bc03810780a77c22755329fed9d715f11fbfb0b6caca6997cf1a1d7b2
+    x86_64-linux:
+      url: https://github.com/junegunn/fzf/releases/download/0.36.0/fzf-0.36.0-linux_amd64.tar.gz
+      sha256: 7e6271c7935ba0e92fc04eca346a2b2320561ca862b6bc76301376b70b3558b3
+    x86_64-macos:
+      url: https://github.com/junegunn/fzf/releases/download/0.36.0/fzf-0.36.0-darwin_amd64.zip
+      sha256: 5dc2b9c152de5fe3ea6301af31b73f04c4de0dc3b874a9f93cf4a8cd32a976e5
+    x86_64-windows:
+      url: https://github.com/junegunn/fzf/releases/download/0.36.0/fzf-0.36.0-windows_amd64.zip
+      sha256: d74716749e0916cc83aca6bc3b9a36e66e9201ce0d36a6640739f8861c1d1835
+  0.37.0:
+    aarch64-linux:
+      url: https://github.com/junegunn/fzf/releases/download/0.37.0/fzf-0.37.0-linux_arm64.tar.gz
+      sha256: f270acb5fbf0f4d29a3589e4ccab8f8cf0737651d616d98c299acf11b37f3d92
+    aarch64-macos:
+      url: https://github.com/junegunn/fzf/releases/download/0.37.0/fzf-0.37.0-darwin_arm64.zip
+      sha256: 6fa83826b5c4ab4e1cc923f5628e1c5858bbe328ed23e4ad9a33e61186a5d662
+    aarch64-windows:
+      url: https://github.com/junegunn/fzf/releases/download/0.37.0/fzf-0.37.0-windows_arm64.zip
+      sha256: 705def97af3b832f0ab41e1f26f1c704919db342941884a315695059eeed5f3d
+    x86_64-linux:
+      url: https://github.com/junegunn/fzf/releases/download/0.37.0/fzf-0.37.0-linux_amd64.tar.gz
+      sha256: ffa3220089f2ed6ddbef2d54795e49f46467acfadd4ad0d22c5f07c52dc0d4ab
+    x86_64-macos:
+      url: https://github.com/junegunn/fzf/releases/download/0.37.0/fzf-0.37.0-darwin_amd64.zip
+      sha256: edfde9baf2876e63d5693ceb2349d7ceb7cbc67972abdca5fc49e342ac616e9d
+    x86_64-windows:
+      url: https://github.com/junegunn/fzf/releases/download/0.37.0/fzf-0.37.0-windows_amd64.zip
+      sha256: 247bffe84ff3294a8c0a7bb96329d5e4152d3d034e13dec59dcc97d8a828000d
 installs:
   0.27.2:
     any-any:
       files:
         fzf${exe_ext}: bin/
       tests:
-        - fzf${exe_ext} --version
+      - fzf${exe_ext} --version
+fetcher: Auto

--- a/gh.yaml
+++ b/gh.yaml
@@ -404,6 +404,50 @@ releases:
     x86_64-windows:
       url: https://github.com/cli/cli/releases/download/v2.21.2/gh_2.21.2_windows_amd64.zip
       sha256: f6e4aead0cd85cb50f811f4a3497f288f52a013589b48e684ec617510463580f
+  2.22.0:
+    aarch64-linux:
+      url: https://github.com/cli/cli/releases/download/v2.22.0/gh_2.22.0_linux_arm64.tar.gz
+      sha256: 33d36e860fecefc3441faadaf91b993899dfc0d1e6ede458c83bafe906d8ae15
+    aarch64-windows:
+      url: https://github.com/cli/cli/releases/download/v2.22.0/gh_2.22.0_windows_arm64.zip
+      sha256: dd44b889250248a2ae8d73ca9a8b6535a1ed687413c0f2588eec9aed00d891d7
+    x86-linux:
+      url: https://github.com/cli/cli/releases/download/v2.22.0/gh_2.22.0_linux_386.tar.gz
+      sha256: cf485d2c10ce0551d686611fe6ff0d628afb14f33f38e62fa461b2e96e91135c
+    x86-windows:
+      url: https://github.com/cli/cli/releases/download/v2.22.0/gh_2.22.0_windows_386.zip
+      sha256: 26f7e81b6b5d4e62ea15ca6edc8c889259b9a1a551376b5b8140e3c2a1980e37
+    x86_64-linux:
+      url: https://github.com/cli/cli/releases/download/v2.22.0/gh_2.22.0_linux_amd64.tar.gz
+      sha256: 065d78c51f4e400c1dfe4e3cdc14832ff8d5204926a485f5ae06d52f411eec04
+    x86_64-macos:
+      url: https://github.com/cli/cli/releases/download/v2.22.0/gh_2.22.0_macOS_amd64.tar.gz
+      sha256: f69c0073ee16adaf14d3537a8e439c0bbd3c1d581210d363d902a682cd8f54d6
+    x86_64-windows:
+      url: https://github.com/cli/cli/releases/download/v2.22.0/gh_2.22.0_windows_amd64.zip
+      sha256: 39fdfe5a03ab40bf98e1376e5ac44ea5b6227f1562f8f1632b6d91700077e0ac
+  2.22.1:
+    aarch64-linux:
+      url: https://github.com/cli/cli/releases/download/v2.22.1/gh_2.22.1_linux_arm64.tar.gz
+      sha256: 9122024da9fe47e15c718dbd8a57c07f9750e6312ad91b405d835b0dd44f746d
+    aarch64-windows:
+      url: https://github.com/cli/cli/releases/download/v2.22.1/gh_2.22.1_windows_arm64.zip
+      sha256: b74185710809558bc12d6f1c7df6460bc928506732a528502e8b273e67e16141
+    x86-linux:
+      url: https://github.com/cli/cli/releases/download/v2.22.1/gh_2.22.1_linux_386.tar.gz
+      sha256: 81c2e6b7ab316460bb5d72ab5605fda5e481b3a6162d0425dd1837ebee3077c6
+    x86-windows:
+      url: https://github.com/cli/cli/releases/download/v2.22.1/gh_2.22.1_windows_386.zip
+      sha256: c80a1d30e6bae37661c4368f7a375e0f0be520cc1741254fa752ffccae0155f5
+    x86_64-linux:
+      url: https://github.com/cli/cli/releases/download/v2.22.1/gh_2.22.1_linux_amd64.tar.gz
+      sha256: 76f7e18bdad5ddfdfcab40fce86c8d6f9fb27f9d29c1287cdf71e0d6b45ba84b
+    x86_64-macos:
+      url: https://github.com/cli/cli/releases/download/v2.22.1/gh_2.22.1_macOS_amd64.tar.gz
+      sha256: a9af43a3e55e4460388d46c372a9e94def67c17ae700af11e5084dea30846d41
+    x86_64-windows:
+      url: https://github.com/cli/cli/releases/download/v2.22.1/gh_2.22.1_windows_amd64.zip
+      sha256: b51fdf145f472a63b4dbcb05b5eac843abaefbbb73aeaab9a67cadef9c8f22b1
 installs:
   2.11.3:
     any-any:

--- a/git-delta.yaml
+++ b/git-delta.yaml
@@ -1,0 +1,37 @@
+name: git-delta
+description: A syntax-highlighting pager for git, diff, and grep output
+homepage: https://github.com/dandavison/delta
+repository: https://github.com/dandavison/delta
+releases:
+  0.15.1:
+    aarch64-linux:
+      url: https://github.com/dandavison/delta/releases/download/0.15.1/delta-0.15.1-aarch64-unknown-linux-gnu.tar.gz
+      sha256: ab3b7d7b87c679a9cb464a6b8731f53d2e36b39268d63a4f8ed3e141efc3915d
+    aarch64-macos:
+      url: https://github.com/dandavison/delta/releases/download/0.15.1/delta-0.15.1-aarch64-apple-darwin.tar.gz
+      sha256: ba06f9709b3e8014210bf4461b60904805b1d06f09fca8df641e92cb8636cb17
+    x86-linux:
+      url: https://github.com/dandavison/delta/releases/download/0.15.1/delta-0.15.1-i686-unknown-linux-gnu.tar.gz
+      sha256: 6f37d14badc55454a7095793255b826d7f846c1b3fe263e40b1c1c2efdbf5918
+    x86_64-linux:
+      url: https://github.com/dandavison/delta/releases/download/0.15.1/delta-0.15.1-x86_64-unknown-linux-musl.tar.gz
+      sha256: f2499f34a4355a808c084764dcb37b613af4d45af28d8f8fb5a0739eeb2839f9
+    x86_64-macos:
+      url: https://github.com/dandavison/delta/releases/download/0.15.1/delta-0.15.1-x86_64-apple-darwin.tar.gz
+      sha256: a7abcdbf9977bbc8bf5bead8bef10b71d19719d52c6f0ebea6b5fb0deced2b2a
+    x86_64-windows:
+      url: https://github.com/dandavison/delta/releases/download/0.15.1/delta-0.15.1-x86_64-pc-windows-msvc.zip
+      sha256: 4ba69ba67eff330b5479873704a0ec86820671c735f06998697e7d0f3e7335fa
+installs:
+  0.15.1:
+    any-any:
+      strip: 1
+      files:
+        delta${exe_ext}: bin/
+        LICENSE: ${doc_dir}/
+        README.md: ${doc_dir}/
+fetcher: Auto
+tests:
+  0.15.1:
+    any-any:
+      - delta${exe_ext} --version

--- a/gitea.yaml
+++ b/gitea.yaml
@@ -135,6 +135,50 @@ releases:
     x86_64-windows:
       url: https://github.com/go-gitea/gitea/releases/download/v1.18.0/gitea-1.18.0-gogit-windows-4.0-amd64.exe.xz
       sha256: 42fc7ba45f532d401abaa20a497fe16a4f574fbfa92820819c6753662a654f52
+  1.18.2:
+    aarch64-linux:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.2/gitea-1.18.2-linux-arm64.xz
+      sha256: 3b71edb2340675667dd5bf8fa8d91383fa3351541853fe2b14d7d0fcdba8283f
+    aarch64-macos:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.2/gitea-1.18.2-darwin-10.12-arm64.xz
+      sha256: c098950f19239ab83c4ac79d1df82c932fc9bfb23a8139ab1406ed9703f38c06
+    x86-linux:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.2/gitea-1.18.2-linux-386.xz
+      sha256: efc6d76a2e33dc424d95ec99592dd4a13b3e2cb9b799e459ad953fab5aff4d19
+    x86-windows:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.2/gitea-1.18.2-gogit-windows-4.0-386.exe.xz
+      sha256: 859bbeea60a962c58d45753bc8694e2251948f4ba10c7d329393900716130e44
+    x86_64-linux:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.2/gitea-1.18.2-linux-amd64.xz
+      sha256: 60c86f4d61da12e04ec38a22f30ee499bfd7c43e6986e733e32007c748e0e5fd
+    x86_64-macos:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.2/gitea-1.18.2-darwin-10.12-amd64.xz
+      sha256: 7918e02e51e34a335a72f7c46374e7b94276e255c7457570eb71b38f85288a19
+    x86_64-windows:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.2/gitea-1.18.2-gogit-windows-4.0-amd64.exe.xz
+      sha256: cf5155b754414c629685fb2820cb9ac566b09f5c167f26a79fec157c6d6f76b0
+  1.18.3:
+    aarch64-linux:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.3/gitea-1.18.3-linux-arm64.xz
+      sha256: 4257f326fda4a5e8ee96eda0a24a477c129ee3639aead59165cb37be7259bcc2
+    aarch64-macos:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.3/gitea-1.18.3-darwin-10.12-arm64.xz
+      sha256: 4f8034c2d6f2af8f2b59046470390cfd0c6cd48a63c6a01a7903f01e755b1ee9
+    x86-linux:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.3/gitea-1.18.3-linux-386.xz
+      sha256: b066819bf254a6b3c7f70b06388520be576787dff37913388fa83d5f6796a373
+    x86-windows:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.3/gitea-1.18.3-gogit-windows-4.0-386.exe.xz
+      sha256: 2ddd4c1bf9d8c13736d697bb855202550343ea5173cc808518105d36bd6d3c8d
+    x86_64-linux:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.3/gitea-1.18.3-linux-amd64.xz
+      sha256: 60d0f6e16ea7831a5f3acc7edf05ca7832403c8c53fd27876c4dbcc4059e1cd2
+    x86_64-macos:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.3/gitea-1.18.3-darwin-10.12-amd64.xz
+      sha256: d23df79b81249d87dc34b92830b10916af26edc7145c8400964f41ea3b3c1c9a
+    x86_64-windows:
+      url: https://github.com/go-gitea/gitea/releases/download/v1.18.3/gitea-1.18.3-gogit-windows-4.0-amd64.exe.xz
+      sha256: 0e034b6ffa4e4dbd5aa3a3accef60e69838db9d68cc4c6c0e35e37fd11d23014
 installs:
   1.17.0:
     any-any:

--- a/gitui.yaml
+++ b/gitui.yaml
@@ -1,0 +1,29 @@
+name: gitui
+description: Blazing fast terminal-ui for git written in rust
+homepage: https://github.com/extrawurst/gitui
+repository: https://github.com/extrawurst/gitui
+releases:
+  0.22.1:
+    aarch64-linux:
+      url: https://github.com/extrawurst/gitui/releases/download/v0.22.1/gitui-linux-aarch64.tar.gz
+      sha256: 1a6562f1a7e4700545f6fdde614e6c2dcba8e2bc608bdc10d221fab51fd22edd
+    x86_64-linux:
+      url: https://github.com/extrawurst/gitui/releases/download/v0.22.1/gitui-linux-musl.tar.gz
+      sha256: 03877698f3dc2d8f332bd65d872fa7d88d79004feca703394bdb928bd13f1955
+    x86_64-macos:
+      url: https://github.com/extrawurst/gitui/releases/download/v0.22.1/gitui-mac.tar.gz
+      sha256: fc7cf26e8e35ee50519521a67dcb4782058931bdd6eaaaecd74379731042d7f1
+    x86_64-windows:
+      url: https://github.com/extrawurst/gitui/releases/download/v0.22.1/gitui-win.tar.gz
+      sha256: c50ee9ff2ab7b9a1f14f821abfd1f69decda619fa2b99932dcc5769f5049b29d
+installs:
+  0.22.1:
+    any:
+      files:
+        gitui${exe_ext}: bin/
+fetcher: !GitHub
+  arch: x86_64
+tests:
+  0.22.1:
+    any:
+      - gitui${exe_ext} --version

--- a/gum.yaml
+++ b/gum.yaml
@@ -157,6 +157,28 @@ releases:
     x86_64-windows:
       url: https://github.com/charmbracelet/gum/releases/download/v0.8.0/gum_0.8.0_Windows_x86_64.zip
       sha256: 7c7f124975bf127f28006d1640371cb2d570240f76e82beeb536fb4b86cb8f0c
+  0.9.0:
+    aarch64-linux:
+      url: https://github.com/charmbracelet/gum/releases/download/v0.9.0/gum_0.9.0_Linux_arm64.tar.gz
+      sha256: 08d8ced9a9ba51b635a7261d3a629c2c02aac758ab1a9bb38b31c6d8172172fb
+    aarch64-macos:
+      url: https://github.com/charmbracelet/gum/releases/download/v0.9.0/gum_0.9.0_Darwin_arm64.tar.gz
+      sha256: 3c3546f550b07c607786ef7057f19218f007adb1929229f5caddca71446c1522
+    x86-linux:
+      url: https://github.com/charmbracelet/gum/releases/download/v0.9.0/gum_0.9.0_Linux_i386.tar.gz
+      sha256: eedcfd9d6f733d2f242dbcaefb05dd13b9ccd92478721f2088a5ec3b900284a3
+    x86-windows:
+      url: https://github.com/charmbracelet/gum/releases/download/v0.9.0/gum_0.9.0_Windows_i386.zip
+      sha256: 0a35e959a0ac2009106e1215e7ee7569e60f37e39fcbea35b861bafb28d6cab4
+    x86_64-linux:
+      url: https://github.com/charmbracelet/gum/releases/download/v0.9.0/gum_0.9.0_Linux_x86_64.tar.gz
+      sha256: 97bc684a47aa289be43f83b4c940b00b28b34ee4a8d5c5aa979966f4ab927a4b
+    x86_64-macos:
+      url: https://github.com/charmbracelet/gum/releases/download/v0.9.0/gum_0.9.0_Darwin_x86_64.tar.gz
+      sha256: d8752e0496455bfdcddb2213523777b679c8eb86c3daac8ab6ce0e83aeeff3b5
+    x86_64-windows:
+      url: https://github.com/charmbracelet/gum/releases/download/v0.9.0/gum_0.9.0_Windows_x86_64.zip
+      sha256: febb4d75e7df9f191d37f64bb5756f144d269bab292e5d99047e2145ea8e67f3
 installs:
   0.1.0:
     any-any:
@@ -166,4 +188,5 @@ installs:
         gum${exe_ext}: bin/
         manpages/gum.1.gz: share/man/man1/
       tests:
-        - gum${exe_ext} --version
+      - gum${exe_ext} --version
+fetcher: Auto

--- a/hadolint.yaml
+++ b/hadolint.yaml
@@ -1,0 +1,27 @@
+name: hadolint
+description: Dockerfile linter, validate inline bash, written in Haskell
+homepage: https://github.com/hadolint/hadolint
+repository: https://github.com/hadolint/hadolint
+releases:
+  2.12.0:
+    aarch64-linux:
+      url: https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-arm64
+      sha256: 5798551bf19f33951881f15eb238f90aef023f11e7ec7e9f4c37961cb87c5df6
+    x86_64-linux:
+      url: https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64
+      sha256: 56de6d5e5ec427e17b74fa48d51271c7fc0d61244bf5c90e828aab8362d55010
+    x86_64-macos:
+      url: https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Darwin-x86_64
+      sha256: 2a5b7afcab91645c39a7cebefcd835b865f7488e69be24567f433dfc3d41cd27
+    x86_64-windows:
+      url: https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Windows-x86_64.exe
+      sha256: ed89a156290e15452276b2b4c84efa688a5183d3b578bfaec7cfdf986f0632a8
+installs:
+  2.12.0:
+    any-any:
+      files:
+        ${asset_name}: bin/hadolint${exe_ext}
+tests:
+  2.12.0:
+    any:
+      - hadolint${exe_ext} --version

--- a/just.yaml
+++ b/just.yaml
@@ -19,6 +19,38 @@ releases:
     x86_64-windows:
       url: https://github.com/casey/just/releases/download/1.11.0/just-1.11.0-x86_64-pc-windows-msvc.zip
       sha256: 43fdee33348907a3771341d5949ec78283bacc711c7aa7336a80fc938627ce68
+  1.12.0:
+    aarch64-linux:
+      url: https://github.com/casey/just/releases/download/1.12.0/just-1.12.0-aarch64-unknown-linux-musl.tar.gz
+      sha256: a8f990336308179103c7776b463f89d751d7c910b757765dd47713b4a32b93a1
+    aarch64-macos:
+      url: https://github.com/casey/just/releases/download/1.12.0/just-1.12.0-aarch64-apple-darwin.tar.gz
+      sha256: d08bcc10a690fed8db84e7a64c8665e69d56ad601a85fa970f0a82bee23ec204
+    x86_64-linux:
+      url: https://github.com/casey/just/releases/download/1.12.0/just-1.12.0-x86_64-unknown-linux-musl.tar.gz
+      sha256: a8e1278f3a2c81384f9a146e74fc40b5204f00776cccfb4da4d36e45716546d4
+    x86_64-macos:
+      url: https://github.com/casey/just/releases/download/1.12.0/just-1.12.0-x86_64-apple-darwin.tar.gz
+      sha256: 22eeed0bcff05f5cd280345b611a9950b81c3a5b4cabb925cf5c0c77475b2dfd
+    x86_64-windows:
+      url: https://github.com/casey/just/releases/download/1.12.0/just-1.12.0-x86_64-pc-windows-msvc.zip
+      sha256: a19d34d8b08e08a2d5b6839db6ece5bfd05faefa45b8924ecbe93f07d3e86e76
+  1.13.0:
+    aarch64-linux:
+      url: https://github.com/casey/just/releases/download/1.13.0/just-1.13.0-aarch64-unknown-linux-musl.tar.gz
+      sha256: 1afff4cc864a31c0e167c8b4ea5f68c4f358c6d3a19d764276cbdaa2c1575a52
+    aarch64-macos:
+      url: https://github.com/casey/just/releases/download/1.13.0/just-1.13.0-aarch64-apple-darwin.tar.gz
+      sha256: b6c7489f103e154f1ec99e648b70323aff7173e16f18ea2e22d3d21e52283851
+    x86_64-linux:
+      url: https://github.com/casey/just/releases/download/1.13.0/just-1.13.0-x86_64-unknown-linux-musl.tar.gz
+      sha256: f76fce93a71686f6aa6b2db1a39184e736f9ac8248c0489e003c617b49eb2676
+    x86_64-macos:
+      url: https://github.com/casey/just/releases/download/1.13.0/just-1.13.0-x86_64-apple-darwin.tar.gz
+      sha256: fb14ec72f0900789b3452ec6bd90becef6de1420c8bb4abc0686e7e0efa99d83
+    x86_64-windows:
+      url: https://github.com/casey/just/releases/download/1.13.0/just-1.13.0-x86_64-pc-windows-msvc.zip
+      sha256: cbb956c59b3b2d48011630fed626f13340b5692aba45833301bdf696dccb51c8
   1.2.0:
     aarch64-linux:
       url: https://github.com/casey/just/releases/download/1.2.0/just-1.2.0-aarch64-unknown-linux-musl.tar.gz

--- a/nushell.yaml
+++ b/nushell.yaml
@@ -199,6 +199,38 @@ releases:
     x86_64-windows:
       url: https://github.com/nushell/nushell/releases/download/0.73.0/nu-0.73.0-x86_64-pc-windows-msvc.zip
       sha256: 328120fa2752814e60ceae5416ec5544f92af8865c5d7e638a6e0e82ba16af9f
+  0.74.0:
+    aarch64-linux:
+      url: https://github.com/nushell/nushell/releases/download/0.74.0/nu-0.74.0-aarch64-unknown-linux-gnu.tar.gz
+      sha256: 4e2d216d731e07c4232ae4f455c3eb779bb9a056c3d05b181e2164098c6a02db
+    aarch64-macos:
+      url: https://github.com/nushell/nushell/releases/download/0.74.0/nu-0.74.0-aarch64-apple-darwin.tar.gz
+      sha256: 145a831e1652390f67540e4fc7651b78b572634fea952c22942d10034b4288b5
+    x86_64-linux:
+      url: https://github.com/nushell/nushell/releases/download/0.74.0/nu-0.74.0-x86_64-unknown-linux-musl.tar.gz
+      sha256: 32b5b88124b498161159513fee293bfb0e8a93238f52f78e013941d578732bfe
+    x86_64-macos:
+      url: https://github.com/nushell/nushell/releases/download/0.74.0/nu-0.74.0-x86_64-apple-darwin.tar.gz
+      sha256: c2adb8067d5792bbd05213ee26fe4595c5229ba5792bec3488d1cdb06dc94683
+    x86_64-windows:
+      url: https://github.com/nushell/nushell/releases/download/0.74.0/nu-0.74.0-x86_64-pc-windows-msvc.zip
+      sha256: 49c97a7a31ed51a20d1ae00e4fa9b9076c96b017315cda4451e87a3db51698d4
+  0.75.0:
+    aarch64-linux:
+      url: https://github.com/nushell/nushell/releases/download/0.75.0/nu-0.75.0-aarch64-unknown-linux-gnu.tar.gz
+      sha256: 5d952fe49ed3641375201161e04fc0015737aa5c93755ab8ae903811a7ce0247
+    aarch64-macos:
+      url: https://github.com/nushell/nushell/releases/download/0.75.0/nu-0.75.0-aarch64-apple-darwin.tar.gz
+      sha256: d7ac819a75cce9d4b3eb3dc9d90e6ae51bd383530b58bf03264f1f194345d968
+    x86_64-linux:
+      url: https://github.com/nushell/nushell/releases/download/0.75.0/nu-0.75.0-x86_64-unknown-linux-musl.tar.gz
+      sha256: 3598dd0319bcb9aaa82005fa3beacbd3cb24c0199951057a7a2cf5072784d570
+    x86_64-macos:
+      url: https://github.com/nushell/nushell/releases/download/0.75.0/nu-0.75.0-x86_64-apple-darwin.tar.gz
+      sha256: c39f36b41bdb584347af440bfeb6ec2715975635f43f2e07f685ea1107748a33
+    x86_64-windows:
+      url: https://github.com/nushell/nushell/releases/download/0.75.0/nu-0.75.0-x86_64-pc-windows-msvc.zip
+      sha256: b6c2035a7fee3d354b60de3c271f96d19c839cc56ffa95588d5bb6793903413d
 installs:
   0.64.0:
     any-any:

--- a/pandoc.yaml
+++ b/pandoc.yaml
@@ -43,6 +43,26 @@ releases:
     x86_64-windows:
       url: https://github.com/jgm/pandoc/releases/download/2.19.2/pandoc-2.19.2-windows-x86_64.zip
       sha256: e7a0c92b4af6cad31d9899a8b92a3992e18634320349bbf56b729bbbcf71bb99
+  3.0.0:
+    aarch64-linux:
+      url: https://github.com/jgm/pandoc/releases/download/3.0/pandoc-3.0-linux-arm64.tar.gz
+      sha256: 6c093554bd75a3c4431aa9613d31162b2d1745f4f468af6eb6bffeff40ab0dd0
+    x86_64-linux:
+      url: https://github.com/jgm/pandoc/releases/download/3.0/pandoc-3.0-linux-amd64.tar.gz
+      sha256: 0fe2ef8366a61b9296ef4a8512b9a2d4acd056c7f92ce7e0cc82add960c2cc8f
+    x86_64-windows:
+      url: https://github.com/jgm/pandoc/releases/download/3.0/pandoc-3.0-windows-x86_64.zip
+      sha256: fdcec5ddec35f76fa5fe2ae742fc2ce71d694fdb17c577f0cf4e3f623a9d89ab
+  3.0.1:
+    aarch64-linux:
+      url: https://github.com/jgm/pandoc/releases/download/3.0.1/pandoc-3.0.1-linux-arm64.tar.gz
+      sha256: 4e3441ed831f63eb624ba4080a1fbdaa4697390d6494973d0c4f2e5ba109e573
+    x86_64-linux:
+      url: https://github.com/jgm/pandoc/releases/download/3.0.1/pandoc-3.0.1-linux-amd64.tar.gz
+      sha256: b8b0051a3c27ab5802bb2a091c8dd5cdb6588ce7356a6d5c4e64fbf02225da04
+    x86_64-windows:
+      url: https://github.com/jgm/pandoc/releases/download/3.0.1/pandoc-3.0.1-windows-x86_64.zip
+      sha256: 32c8de0bd205eaf411d1990a1ecf6d9a6f67f8836bd39de80ea5f6226028d9fc
 installs:
   2.18.0:
     any-any:
@@ -51,7 +71,7 @@ installs:
         bin: bin
         share: share
       tests:
-        - pandoc${exe_ext} --version
+      - pandoc${exe_ext} --version
     any-windows:
       strip: 1
       files:
@@ -60,4 +80,5 @@ installs:
         MANUAL.html: ${doc_dir}
         pandoc${exe_ext}: bin/
       tests:
-        - pandoc${exe_ext} --version
+      - pandoc${exe_ext} --version
+fetcher: Auto

--- a/sylver-cli.yaml
+++ b/sylver-cli.yaml
@@ -1,0 +1,27 @@
+name: sylver-cli
+description: Language agnostic source code exploration and analysis.
+homepage: https://github.com/sylver-dev/sylver-cli
+repository: https://github.com/sylver-dev/sylver-cli
+releases:
+  0.2.4:
+    aarch64-macos:
+      url: https://github.com/sylver-dev/sylver-cli/releases/download/v0.2.4/sylver--aarch64-macos.tar.xz
+      sha256: 4a89d92c61856269cf6b91deb12b686d5b9bed702bff252fde312d47b74a1abf
+    x86_64-linux:
+      url: https://github.com/sylver-dev/sylver-cli/releases/download/v0.2.4/sylver--x86_64-linux.tar.xz
+      sha256: 7d14118dadb697fe6e0df2128c2e0756afb15a038343f7a8dc8953adf2eaa671
+    x86_64-macos:
+      url: https://github.com/sylver-dev/sylver-cli/releases/download/v0.2.4/sylver--x86_64-macos.tar.xz
+      sha256: 658b861201a45e85e062a1db5c4f891f495310bd1f3002224027c66424736945
+    x86_64-windows:
+      url: https://github.com/sylver-dev/sylver-cli/releases/download/v0.2.4/sylver--x86_64-windows.zip
+      sha256: ad125861ed3e4b55cd38192a98c74897629794f4b370f168b92d5ae46dc27f92
+installs:
+  0.2.4:
+    any-any:
+      files:
+        sylver${exe_ext}: bin/
+tests:
+  0.2.4:
+    any:
+      - sylver${exe_ext} --version

--- a/vault.yaml
+++ b/vault.yaml
@@ -9,7 +9,7 @@ releases:
       sha256: 7b35d12518729cfe3efe2007a07862934b0a6df053146ea15243f89e6b0bfbf2
     aarch64-macos:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_darwin_arm64.zip
-      sha256: f1fa420858eb8674416a2285cb48f9887c680eb3437235cc06c69a30178de708
+      sha256: 24dc14e1492cea39442ff8754ffed4b58e9d703342f8c93fa61b5006a4b4c568
     x86-linux:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_linux_386.zip
       sha256: a28e1093b1a289634280710dcaf11acba3aad4572bee9c4dd3a614fecee89a66
@@ -21,7 +21,7 @@ releases:
       sha256: 116c143de377a77a7ea455a367d5e9fe5290458e8a941a6e2dd85d92aaedba67
     x86_64-macos:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_darwin_amd64.zip
-      sha256: 76d985c42a254bf16fa55fbf39092a34e27aba22942c2f829a6ce81ac5fdc40f
+      sha256: d1ff82c1fc192f027eb5ba81ebaa519166037c53faa43cc38b886678100188ef
     x86_64-windows:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_windows_amd64.zip
       sha256: 0421531b5846a45a53547bc9a505de2b11d91d0a48fdb5aed1d77259720db5ab


### PR DESCRIPTION
- Unbreak build failure on Windows + "next"
- Add GitUI
- Add tests for gitui package
- Add delta
- Update d2
- Update difftastic
- Update gum
- Update nushell
- Update act
- Update datree
- Update fzf
- Make ci/fetch use clyde from latest snapshot
- ci/fetch: do not download clyde in --only-pr mode
- ci/fetch: make sure branches start from the base branch and target it
- Update cmake
- Update d2
- Update difftastic
- Update gitea
- Update just
- Update pandoc
- Update fzf
- Update gitea
- Update just
- Update changie
- Update datree
- Update gh
- Update pandoc
- Add sylver-cli
- Update gh
- Add hadolint
- Add dive
- Update act
- Update datree
- Update nushell
- Fix vault macOS binaries not passing CI anymore
