### PR TITLE
Fix 1.12.2 macOS checksums

### DIFF
--- a/vault.yaml
+++ b/vault.yaml
@@ -25,10 +25,33 @@ releases:
     x86_64-windows:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_windows_amd64.zip
       sha256: 0421531b5846a45a53547bc9a505de2b11d91d0a48fdb5aed1d77259720db5ab
+  1.13.0:
+    aarch64-linux:
+      url: https://releases.hashicorp.com/vault/1.13.0/vault_1.13.0_linux_arm64.zip
+      sha256: 3234f989678d510f54e0ca20c93e045a9b1a86e337b09f2962e573b81c9a9ebf
+    aarch64-macos:
+      url: https://releases.hashicorp.com/vault/1.13.0/vault_1.13.0_darwin_arm64.zip
+      sha256: f43f952b51bd0972e49b2051ac314e8ba4cfcf04c1623269a5541255968a8570
+    x86-linux:
+      url: https://releases.hashicorp.com/vault/1.13.0/vault_1.13.0_linux_386.zip
+      sha256: dde59183cbe41c9b2062fb293c08393380d76bd00d02c9dcfa00b5941544ef1d
+    x86-windows:
+      url: https://releases.hashicorp.com/vault/1.13.0/vault_1.13.0_windows_386.zip
+      sha256: 9e06b0a2ff00ec95662aa86c2bdfb7dddae6e4dec1c4b205baefb9f724fce58e
+    x86_64-linux:
+      url: https://releases.hashicorp.com/vault/1.13.0/vault_1.13.0_linux_amd64.zip
+      sha256: 69c1ce6dd383bb342c4f861a51a91413eb05e1324159e4395532e42a8a59af9d
+    x86_64-macos:
+      url: https://releases.hashicorp.com/vault/1.13.0/vault_1.13.0_darwin_amd64.zip
+      sha256: d6cdc97db0db729458b8186f5957fda5a276743b3e342a58f38d8a2bb9ae8abf
+    x86_64-windows:
+      url: https://releases.hashicorp.com/vault/1.13.0/vault_1.13.0_windows_amd64.zip
+      sha256: 158152d48e0798f19e7ecfc74ac35ec1edf260995bb3e6baf4bebafb78b9f047
 installs:
   1.12.0:
-    any:
+    any-any:
       files:
         vault${exe_ext}: bin/
       tests:
-        - vault${exe_ext} --version
+      - vault${exe_ext} --version
+fetcher: Off

--- a/vault.yaml
+++ b/vault.yaml
@@ -9,7 +9,7 @@ releases:
       sha256: 7b35d12518729cfe3efe2007a07862934b0a6df053146ea15243f89e6b0bfbf2
     aarch64-macos:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_darwin_arm64.zip
-      sha256: 24dc14e1492cea39442ff8754ffed4b58e9d703342f8c93fa61b5006a4b4c568
+      sha256: 549829493c1de6d2e16b01e00b871b87edeb1d8176e94dbb88492e3e99d1ee10
     x86-linux:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_linux_386.zip
       sha256: a28e1093b1a289634280710dcaf11acba3aad4572bee9c4dd3a614fecee89a66
@@ -21,7 +21,7 @@ releases:
       sha256: 116c143de377a77a7ea455a367d5e9fe5290458e8a941a6e2dd85d92aaedba67
     x86_64-macos:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_darwin_amd64.zip
-      sha256: d1ff82c1fc192f027eb5ba81ebaa519166037c53faa43cc38b886678100188ef
+      sha256: a83918e0f48f99cadaeba6ee53214bb3fd1b734ee9ab204571fa401aa6e52b1f
     x86_64-windows:
       url: https://releases.hashicorp.com/vault/1.12.2/vault_1.12.2_windows_amd64.zip
       sha256: 0421531b5846a45a53547bc9a505de2b11d91d0a48fdb5aed1d77259720db5ab


### PR DESCRIPTION
The change most likely comes from https://github.com/hashicorp/vault/issues/19030.
