### PR TITLE
Make more Linux tests pass

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - macos-11
           - windows-2019
 

--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - macos-11
           - windows-2019
 


### PR DESCRIPTION
Switch to Ubuntu 22.04 because some binaries do not run anymore on Ubuntu 20.04.
