### PR TITLE
Update fzf 0.46.0 Windows checksum

### DIFF
--- a/fzf.yaml
+++ b/fzf.yaml
@@ -406,7 +406,7 @@ releases:
       sha256: ce2c6eb28225a85707c809fc59edf11cf6d01c0fb2cb3df34a7d50eedc212d95
     aarch64-windows:
       url: https://github.com/junegunn/fzf/releases/download/0.46.0/fzf-0.46.0-windows_arm64.zip
-      sha256: 00cb61f7ed723ce7f35d1942ab8802f3ad3c16b1089b99cce611bd157cff6e20
+      sha256: 6b03285fe26f1ae8a1b06203af56db9cc366ecf9c6fc7601b3f5dc5e5b82105e
     x86_64-linux:
       url: https://github.com/junegunn/fzf/releases/download/0.46.0/fzf-0.46.0-linux_amd64.tar.gz
       sha256: 122da61584a9aef38f23597b0e5f10416ab3a4ad78b6f20d632d03e35ced63c1
@@ -415,7 +415,7 @@ releases:
       sha256: 410e1f142a313a5fbe192ce958a14b790570647db475f22193f0c95f0f71c6bf
     x86_64-windows:
       url: https://github.com/junegunn/fzf/releases/download/0.46.0/fzf-0.46.0-windows_amd64.zip
-      sha256: 8acabc8408b1ccb3354df65972c632151bb87d6e7f30ebf2069b74d66062b8f6
+      sha256: 813de0c9b71d0a6c97015536ea26c72fb4fffca231095861d024e3fe2a6a2624
 installs:
   0.27.2:
     any-any:


### PR DESCRIPTION
Upstream updated binaries, see
https://github.com/junegunn/fzf/issues/3598.
