### PR TITLE
ci: use ubuntu-latest

### DIFF
--- a/.github/workflows/check-packages-main.yml
+++ b/.github/workflows/check-packages-main.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-latest
           - macos-15-intel
           # ARM based
           - macos-14

--- a/.github/workflows/check-packages-next.yml
+++ b/.github/workflows/check-packages-next.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - ubuntu-22.04
+          - ubuntu-latest
           - macos-15-intel
           # ARM based
           - macos-14

--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   fetch:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
The goal of the CI here is to check the packages work on Linux, not to
check they work on an old version of Linux, so use ubuntu-latest instead
of ubuntu-22.04.
